### PR TITLE
Introduce default argument in commands parsing

### DIFF
--- a/nipap-cli/nipap_cli/command.py
+++ b/nipap-cli/nipap_cli/command.py
@@ -124,6 +124,10 @@ class Command:
                 # if the element we reached has an executable registered, save it!
                 if 'exec' in val:
                     self.exe = val['exec']
+                    try:
+                        self.arg = val['argument']['default']
+                    except:
+                        pass
 
                 # Elements wich takes arguments need special attention
                 if 'argument' in val:

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -866,6 +866,7 @@ cmds = {
                     'exec': list_prefix,
                     'argument': {
                         'type': 'value',
+                        'default': '',
                         'content_type': unicode,
                         'description': 'Prefix',
                     },


### PR DESCRIPTION
This introduces the possibility to set a default value for an argument in the command line completion module.
With it, we can set the default argument of list_prefix to '' instead of None which it previously defaulted to, since that was set when instantiating the Command class. Not sure this is the correct way to proceed though and it really only fixes the problem for list_prefix. list_schema and list_pool work in a completely different way, since they do not rely on a smart_search_prefix-like function that takes a string as only input.

We could just solve this instead by setting arg = '' if arg was None in the list_prefix function.

Part of #201
