### PR TITLE
Pool resize option

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -897,6 +897,10 @@ def resize_pool(arg, opts):
         res[0].pool = None
         res[0].save()
         print "Prefix %s removed from pool %s." % (res[0].prefix, p.name)
+    else:
+        print >> sys.stderr, "Please supply a prefix to add or remove to %s" % (
+            p.name)
+        sys.exit(1)
 
 def modify_prefix(arg, opts):
     """ Modify the prefix 'arg' with the options 'opts'


### PR DESCRIPTION
This is a basic grow/shrink option for the pools.

I'd like to improve it on the completion part:

1) if one would type "nipap pool resize X remove" it should complete the command with a listing of prefixes that are in that pool. Can I supply arguments to the complete_something method?

2) I'd like it to spit out that the argument to add and remove are obligatory: Not supplying them with this code is now silent.

Regards,
