### PR TITLE
Update xmlrpc.py to add vrf argument to find_free_prefix

### DIFF
--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -678,7 +678,7 @@ class NipapProtocol(xmlrpc.XMLRPC):
         """
 
         try:
-            return self.nipap.find_free_prefix(args.get('auth'), args.get('args'))
+            return self.nipap.find_free_prefix(args.get('auth'), args.get('vrf'), args.get('args'))
         except NipapError, e:
             return xmlrpclib.Fault(e.error_code, str(e))
 


### PR DESCRIPTION
Fixes find_free_prefix XMLRPC, VRF was not being passed through
