### PR TITLE
Add option to list an explicit prefix

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -309,6 +309,7 @@ def list_prefix(arg, opts):
         search_string = ' '.join(arg)
 
     v = get_vrf(opts.get('vrf_rt'), abort=True)
+    explicit = opts.get('explicit')
 
     if v.rt == 'all':
         vrf_q = None
@@ -344,6 +345,10 @@ def list_prefix(arg, opts):
         for p in res['result']:
             if p.display == False:
                 continue
+
+            if explicit:
+            	if p.display_prefix != search_string:
+            		continue
 
             vrf = None
             if p.vrf is not None:
@@ -1380,6 +1385,9 @@ cmds = {
                                 'description': 'VRF',
                                 'complete': complete_vrf_virtual,
                             },
+                        },
+                        'explicit': {
+                            'type': 'bool'
                         }
                     }
                 },


### PR DESCRIPTION
Before if you wanted to list a prefix in the cli (e.g. `nipap address list 10.123.10.155/24`), all prefixes in the same subnet as well as all parent reservations and assignements were output.

Now with the option 'explicit' you can choose to output only one single prefix.
