### PR TITLE
Implement precalculation of number of children

### DIFF
--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -15,15 +15,7 @@ var PREFIX_BATCH_SIZE = 50;
 
 /*
  * The prefix_list variable is used to keep a copy of all the prefixes
- * currently in the displayed list. Before adding, they are given a new
- * attribute: children. It is used to save information regarding
- * whether the prefix has children or not. These values are allowed:
- *  -2: We have no clue
- *  -1: At least one, but might be more (used for parent prefixes which
- *      was received when a prefix further down was requested including
- *      parents)
- *   0: No children
- *  >0: Has children
+ * currently in the displayed list.
  */
 var prefix_list = new Object();
 var pool_list = new Object();
@@ -278,21 +270,6 @@ function ajaxErrorHandler(e, jqXHR, ajaxSettings, thrownError) {
  *********************************************************************/
 
 /*
- * Toggles a collapse group
- */
-function toggleGroup(id) {
-
-	var col = $('#collapse' + id);
-
-	if (col.css('display') == 'none') {
-		expandGroup(id);
-	} else {
-		collapseGroup(id);
-	}
-
-}
-
-/*
  * Expands a collapse group
  */
 function expandGroup(id) {
@@ -301,13 +278,7 @@ function expandGroup(id) {
 	var exp = $('#prefix_exp' + id);
 
 	col.slideDown();
-	if (prefix_list[id].children < 0) {
-		// there might be additional children, display a +!
-		exp.html('+');
-	} else {
-		exp.html('&ndash;');
-	}
-
+	exp.html('&ndash;');
 }
 
 /*
@@ -567,7 +538,7 @@ function showPrefix(prefix, reference, offset) {
 	prefix_exp.addClass("prefix_exp");
 
 	// If the prefixes has children (or we do not know), add expand button
-	if (prefix.children == 0 || hasMaxPreflen(prefix)) {
+	if (prefix.children == 0) {
 
 		// the prefix_indent container must contain _something_
 		prefix_exp.html('&nbsp;');
@@ -1272,22 +1243,6 @@ function receivePrefixListUpdate(search_result, link_type) {
 		log('Warning: no prefixes returned from list operation.');
 		return true;
 
-	// One result element (the prefix we searched for)
-	} else if (pref_list.length == 1) {
-
-		// remove expand button
-		$("#prefix_indent" + pref_list[0].id).html('&nbsp;');
-		prefix_list[pref_list[0].id].children = 0;
-		return true;
-
-	} else {
-
-		// If the result set we received contains more elements, we assume at
-		// least one of them is a child of the first element and set the number
-		// of children to 1. This is (probably) not the correct value, but will
-		// suffice for giving the right collapse behaviour.
-		prefix_list[pref_list[0].id].children = 1;
-
 	}
 
 	insertPrefixList(pref_list);
@@ -1530,12 +1485,6 @@ function insertPrefix(prefix, prev_prefix) {
 			 }
 		}
 
-		// We know (since we are one indent level below previous) that
-		// it has at least one child.
-		if (prev_prefix.children == -2) {
-			prev_prefix.children = -1;
-		}
-
 		// If prefix has children, do not hide it! Since we are one indent
 		// level under last, the previous prefix is our parent and clearly
 		// has children, thus unhide!
@@ -1746,9 +1695,9 @@ function addHiddenContainer(prefix, reference, offset) {
  */
 function collapseClick(id) {
 
-	// Determine if we need to fetch data
-	if (prefix_list[id].children < 0) {
+	var col = $('#collapse' + id);
 
+	if (col.css('display') == 'none') {
 		var search_q = jQuery.extend({}, current_query);
 		search_q.query_id = query_id;
 		search_q.parent_prefix = id;
@@ -1768,9 +1717,8 @@ function collapseClick(id) {
 		$.getJSON("/xhr/smart_search_prefix", search_q, receivePrefixListUpdate);
 
 	} else {
-		toggleGroup(id);
+		collapseGroup(id);
 	}
-
 }
 
 /*

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -2876,27 +2876,7 @@ class Nipap:
         vlan,
         added,
         last_modified,
-        CASE
-            WHEN type = 'host'
-                THEN 0
-            WHEN type = 'assignment'
-                THEN CASE
-                    -- for all assignments, count number of children.
-                    --
-                    -- the inner query either returns no children or all
-                    -- children for an assignment, so if we have more than one
-                    -- (the parent assignment) we know we have all children
-                    -- and can count them.
-                    --
-                    -- display_prefix casted to cidr throws away the host bits
-                    -- and in effect is the number of children of an assignment
-                    WHEN COUNT(1) OVER (PARTITION BY display_prefix::cidr) > 1
-                        -- do not include the parent prefix in count
-                        THEN COUNT(1) OVER (PARTITION BY display_prefix::cidr) - 1
-                    ELSE -2
-                END
-            ELSE -2
-        END AS children
+        children
     FROM (
         SELECT DISTINCT ON(vrf_rt_order(vrf.rt), p1.prefix) p1.id,
             p1.prefix,
@@ -2919,6 +2899,7 @@ class Nipap:
             p1.vlan,
             p1.added,
             p1.last_modified,
+            p1.children,
             vrf.id AS vrf_id,
             vrf.rt AS vrf_rt,
             vrf.name AS vrf_name,

--- a/tests/xmlrpc.py
+++ b/tests/xmlrpc.py
@@ -841,7 +841,7 @@ class NipapXmlTest(unittest.TestCase):
                         'id': p1['id'],
                         'display_prefix': '1.3.3.0/24',
                         'monitor': None,
-                        'children': -2,
+                        'children': 1,
                         'prefix_length': 24,
                         'type': 'assignment',
                         'match': True,


### PR DESCRIPTION
This implements the calculation and storing of the number of children to
a prefix. Previously we did this calculation kind of on-the-fly when
returning search results but as it is a value that doesn't change much
it is well suited to being calculated beforehand and stored in the
database.

Together with this, a lot of database triggers have been refactored.
Most of the changes pertain to how and when triggers are called and not
their actual function. Instead of triggering children/tag/indent
calculation on all updates we are now using the column based triggers
available in PostgreSQL 9.x to only trigger on changes that would
influence the result. For example, changing the description of a prefix
would not change the indent and so there is no need to trigger indent
calculation on changes to the description column. There is a certain
risk of new bugs as the changes are quite extensive but the unittests
run without fault and I've gone through everything more than once ;)

Naturally, the web UI now uses the values it receives from the backend
on how many children a prefix has. There was quite a lot of logic to
handle guessing the amount of children which has now been removed.

Also clarify certain parts of country code integrity test and fix other
unittests.

Fixes #421.
