### PR TITLE
Avoid creating too many instances of auth classes

### DIFF
--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -110,7 +110,6 @@ class AuthFactory:
             if section_components[0] == 'auth.backends':
                 auth_backend = section_components[1]
                 self._backends[auth_backend] = eval(self._config.get(section, 'type'))
-                self._backends[auth_backend](auth_backend, 'a', 'b', 'c')
 
         self._logger.debug("Registered auth backends %s" % str(self._backends))
 


### PR DESCRIPTION
Every time the AuthFactory is instanciated it creates instances of every
auth backend registered in the config file, which really doesn't make
sense to me. In combination with SQLite never closing its file
descriptors, this leads to exhaustion of fds.

Altered the AuthFactory constructor to not create these instances.

Part of #485
