### PR TITLE
Add a check for db schema version

### DIFF
--- a/nipap-www/nipapwww/controllers/version.py
+++ b/nipap-www/nipapwww/controllers/version.py
@@ -20,4 +20,6 @@ class VersionController(BaseController):
         except:
             c.nipapd_version = 'unknown'
 
+        c.nipap_db_version = pynipap.nipap_db_version()
+
         return render('/version.html')

--- a/nipap-www/nipapwww/templates/version.html
+++ b/nipap-www/nipapwww/templates/version.html
@@ -45,6 +45,19 @@
 				</dd>
 			</dl>
 		</div>
+
+		<div class="rule"></div>
+
+		<div class="option">
+			<dl>
+				<dt>
+				nipap db schema
+				</dt>
+				<dd>
+				{{ c.nipap_db_version }}
+				</dd>
+			</dl>
+		</div>
 	</div>
 </div>
 

--- a/nipap/Makefile
+++ b/nipap/Makefile
@@ -58,7 +58,8 @@ bumpversion:
 	# update debian package nipapd's config and postinst script with current db
 	# version
 	sed -i 's/^CURRENT_DB_VERSION.*/CURRENT_DB_VERSION=$(DB_VER)/' debian/nipapd.config debian/nipapd.postinst
-	# replace version number in nipap/__init__.py
+	# replace version & db_version number in nipap/__init__.py
 	sed -i 's/\(__version__\s*= \)"[^"]\+"/\1"$(VER)"/' nipap/__init__.py
+	sed -i "s/\(__db_version__\s*= \)[0-9]\+/\1$(DB_VER)/" nipap/__init__.py
 	# update debian/changelog
 	../utilities/news2dch.py ../NEWS debian/changelog

--- a/nipap/nipap/__init__.py
+++ b/nipap/nipap/__init__.py
@@ -1,4 +1,5 @@
 __version__		= "0.26.1"
+__db_version__	= 4
 __author__		= "Kristian Larsson, Lukas Garberg"
 __author_email__ = "kll@tele2.net, lukas@spritelink.net"
 __copyright__	= "Copyright 2011-2014, Kristian Larsson, Lukas Garberg"

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -664,6 +664,27 @@ class Nipap:
 
 
 
+    def _get_db_version(self):
+        """ Get the schema version of the nipap psql db.
+        """
+
+        dbname = self._cfg.get('nipapd', 'db_name')
+        self._execute("SELECT description FROM pg_shdescription JOIN pg_database ON objoid = pg_database.oid WHERE datname = '%s'" % dbname)
+        comment = self._curs_pg.fetchone()[0]
+        if comment is None:
+            raise NipapError("Could not find comment of psql database %s" % dbname)
+
+        db_version = None
+        m = re.match('NIPAP database - schema version: ([0-9]+)', comment)
+        if m:
+            db_version = int(m.group(1))
+        else:
+            raise NipapError("Could not match schema version database comment")
+
+        return db_version
+
+
+
 
     #
     # VRF functions

--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -142,6 +142,16 @@ class NipapXMLRPC:
 
 
 
+    @requires_auth
+    def db_version(self, args):
+        """ Returns schema version of nipap psql db
+
+            Returns a string.
+        """
+        return self.nip._get_db_version()
+
+
+
     #
     # VRF FUNCTIONS
     #

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -42,6 +42,7 @@ if __name__ == '__main__':
     parser.add_option("-P", "--pid-file", type="string", help="write a PID file to PID_FILE")
     parser.add_option("--no-pid-file", action="store_true", default=False, help="turn off writing PID file (overrides config file)")
     parser.add_option("--version", action="store_true", help="display version information and exit")
+    parser.add_option("--db-version", dest="dbversion", action="store_true", help="display database schema version information and exit")
 
     (options, args) = parser.parse_args()
 
@@ -119,6 +120,12 @@ if __name__ == '__main__':
             print >> sys.stderr, "Could not drop privileges to user '%s' and group '%s'" % (run_user, run_group)
             sys.exit(1)
 
+    if options.dbversion:
+        from nipap.backend import Nipap
+        nip = Nipap()
+        print "nipap db schema:", nip._get_db_version()
+        sys.exit(0)
+
     # pre-start checks
     from nipap import authlib
     a = authlib.SqliteAuth('local', 'a', 'b', 'c')
@@ -127,6 +134,15 @@ if __name__ == '__main__':
     except authlib.AuthSqliteError, e:
         print >> sys.stderr, "Problem with Sqlite database for local auth: %s" % e
         print >> sys.stderr, "Run 'nipap-passwd --upgrade-database' to upgrade your database."
+        sys.exit(1)
+
+    #check nipap database schema version
+    from nipap.backend import Nipap
+    import nipap
+    nip = Nipap()
+    current_db_version = nip._get_db_version()
+    if current_db_version != nipap.__db_version__:
+        print >> sys.stderr, "NIPAP PostgreSQL database is outdated. Schema version '%s' is required to run but you are using '%s'" % (nipap.__db_version__, current_db_version)
         sys.exit(1)
 
 

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -1117,6 +1117,21 @@ def nipapd_version():
 
 
 
+def nipap_db_version():
+    """ Get schema version of database we're connected to.
+    """
+
+    xmlrpc = XMLRPCConnection()
+    try:
+        return xmlrpc.connection.db_version(
+            {
+                'auth': AuthOptions().options
+            })
+    except xmlrpclib.Fault as xml_fault:
+        raise _fault_to_exception(xml_fault)
+
+
+
 #
 # Define exceptions
 #


### PR DESCRIPTION
nipapd should refuse to start if the PostgreSQL db schema version is outdated.

The up-to-date schema version (required to run) is stored inside nipap/__init__.py
The current schema version is read out of the database comment.

The web-ui ( /version ) will also show the schema version.

Fix for https://github.com/SpriteLink/NIPAP/issues/460
