### PR TITLE
Add user impersonation functionnality

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -388,6 +388,20 @@ def list_prefix(arg, opts):
 
 
 
+def impersonate_user(opts):
+    """ Provide a quick way to perform user impersonation
+        with the nipap_cli package.
+        Drawback : this function must explicitly be called
+        in each add/modify/delete functions
+    """
+
+    realuser = opts.get('asuser')
+    if realuser:
+        pynipap.AuthOptions({'authoritative_source': 'nipap', 'username': realuser})
+
+
+
+
 """
     ADD FUNCTIONS
 """
@@ -395,6 +409,8 @@ def list_prefix(arg, opts):
 def add_prefix(arg, opts):
     """ Add prefix to NIPAP
     """
+
+    impersonate_user(opts)
 
     p = Prefix()
     p.prefix = opts.get('prefix')
@@ -530,6 +546,8 @@ def add_vrf(arg, opts):
     """ Add VRF to NIPAP
     """
 
+    impersonate_user(opts)
+
     v = VRF()
     v.rt = opts.get('rt')
     v.name = opts.get('name')
@@ -548,6 +566,8 @@ def add_vrf(arg, opts):
 def add_pool(arg, opts):
     """ Add a pool.
     """
+
+    impersonate_user(opts)
 
     p = Pool()
     p.name = opts.get('name')
@@ -678,6 +698,8 @@ def remove_vrf(arg, opts):
     """ Remove VRF
     """
 
+    impersonate_user(opts)
+
     res = VRF.list({ 'rt': arg })
     if len(res) < 1:
         print >> sys.stderr, "VRF with [RT: %s] not found." % arg
@@ -701,6 +723,8 @@ def remove_pool(arg, opts):
     """ Remove pool
     """
 
+    impersonate_user(opts)
+
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
         print >> sys.stderr, "No pool with name '%s' found." % arg
@@ -721,6 +745,8 @@ def remove_pool(arg, opts):
 def remove_prefix(arg, opts):
     """ Remove prefix
     """
+
+    impersonate_user(opts)
 
     # set up some basic variables
     remove_confirmed = False
@@ -876,6 +902,8 @@ def modify_vrf(arg, opts):
     """ Modify a VRF with the options set in opts
     """
 
+    impersonate_user(opts)
+
     res = VRF.list({ 'rt': arg })
     if len(res) < 1:
         print >> sys.stderr, "VRF with [RT: %s] not found." % arg
@@ -899,6 +927,8 @@ def modify_vrf(arg, opts):
 def modify_pool(arg, opts):
     """ Modify a pool with the options set in opts
     """
+
+    impersonate_user(opts)
 
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
@@ -927,6 +957,9 @@ def modify_pool(arg, opts):
 def grow_pool(arg, opts):
     """ Expand a pool with the ranges set in opts
     """
+
+    impersonate_user(opts)
+
     if not pool:
         print >> sys.stderr, "No pool with name '%s' found." % arg
         sys.exit(1)
@@ -970,6 +1003,9 @@ def grow_pool(arg, opts):
 def shrink_pool(arg, opts):
     """ Shrink a pool by removing the ranges in opts from it
     """
+
+    impersonate_user(opts)
+
     if not pool:
         print >> sys.stderr, "No pool with name '%s' found." % arg
         sys.exit(1)
@@ -997,12 +1033,15 @@ def modify_prefix(arg, opts):
     """ Modify the prefix 'arg' with the options 'opts'
     """
 
+    impersonate_user(opts)
+
     spec = { 'prefix': arg }
-    spec['vrf_rt'] = get_vrf(opts.get('vrf_rt'), abort=True).rt
+    vrf = get_vrf(opts.get('vrf_rt'), abort=True)
+    spec['vrf_rt'] = vrf.rt
 
     res = Prefix.list(spec)
     if len(res) == 0:
-        print >> sys.stderr, "Prefix %s not found in %s." % (arg, vrf_format(v))
+        print >> sys.stderr, "Prefix %s not found in %s." % (arg, vrf_format(vrf))
         return
 
     p = res[0]
@@ -1254,6 +1293,13 @@ cmds = {
                     'type': 'command',
                     'exec': add_prefix,
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'comment': {
                             'type': 'option',
                             'argument': {
@@ -1420,6 +1466,13 @@ cmds = {
                         'description': 'Prefix to edit',
                     },
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'vrf_rt': {
                             'type': 'option',
                             'argument': {
@@ -1559,7 +1612,14 @@ cmds = {
                         'description': 'Remove address'
                     },
                     'children': {
-	                    'vrf_rt': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
+                        'vrf_rt': {
                             'type': 'option',
                             'argument': {
                                 'type': 'value',
@@ -1606,6 +1666,13 @@ cmds = {
                     'type': 'command',
                     'exec': add_vrf,
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'rt': {
                             'type': 'option',
                             'argument': {
@@ -1689,6 +1756,15 @@ cmds = {
                         'content_type': unicode,
                         'description': 'VRF',
                         'complete': complete_vrf,
+                    },
+                    'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        }
                     }
                 },
 
@@ -1702,6 +1778,13 @@ cmds = {
                         'complete': complete_vrf,
                     },
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'set': {
                             'type': 'command',
                             'exec': modify_vrf,
@@ -1748,6 +1831,13 @@ cmds = {
                     'type': 'command',
                     'exec': add_pool,
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'default-type': {
                             'type': 'option',
                             'argument': {
@@ -1864,6 +1954,15 @@ cmds = {
                         'content_type': unicode,
                         'description': 'Pool name',
                         'complete': complete_pool_name,
+                    },
+                    'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        }
                     }
                 },
 
@@ -1878,6 +1977,13 @@ cmds = {
                         'complete': complete_pool_name,
                     },
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'add': {
                             'type': 'option',
                             'exec': grow_pool,
@@ -1918,6 +2024,13 @@ cmds = {
                         'complete': complete_pool_name,
                     },
                     'children': {
+                        'asuser': {
+                            'type': 'option',
+                            'argument': {
+                                'type': 'value',
+                                'content_type': unicode,
+                            }
+                        },
                         'set': {
                             'type': 'command',
                             'exec': modify_pool,


### PR DESCRIPTION
I needed a way to use impersonation with the CLI. The easiest way I found is to add a specific verb in the add/modify/delete/resize function.

Where are some exemples I used to validate the changes :

```
$ nipap address add prefix 172.31.19.230 vrf 2885681152:666
WARNING: Parent prefix is of type 'assignment'. Automatically setting type 'host' for new prefix.
Prefix 172.31.19.230/22 added to VRF 'TEST-IPMS' [RT: 2885681152:666]

$ nipap address add prefix 172.31.19.231 vrf 2885681152:666 asuser eric.dechaux
WARNING: Parent prefix is of type 'assignment'. Automatically setting type 'host' for new prefix.
Prefix 172.31.19.231/22 added to VRF 'TEST-IPMS' [RT: 2885681152:666]



$ nipap address modify 172.31.19.231 vrf 2885681152:666 set prefix 172.31.19.232
Prefix 172.31.19.232/22 in VRF 'TEST-IPMS' [RT: 2885681152:666] saved.

$ nipap address modify 172.31.19.230 vrf 2885681152:666 as eric.dechaux set prefix 172.31.19.231 
Prefix 172.31.19.231/22 in VRF 'TEST-IPMS' [RT: 2885681152:666] saved.



$ nipap address remove 172.31.19.231
Do you really want to remove the prefix 172.31.19.231/32 in VRF 'TEST-IPMS' [RT: 2885681152:666]? [y/n]: y
Prefix 172.31.19.231/32 in VRF 'TEST-IPMS' [RT: 2885681152:666] removed.

$ nipap address remove 172.31.19.232 asus eric.dehaux
Do you really want to remove the prefix 172.31.19.232/32 in VRF 'TEST-IPMS' [RT: 2885681152:666]? [y/n]: y
Prefix 172.31.19.232/32 in VRF 'TEST-IPMS' [RT: 2885681152:666] removed.



$ nipap vrf add rt 6:66
Added VRF 'None' [RT: 6:66]

$ nipap vrf add name toto rt 666:666 asuser eric.dechaux
Added VRF 'toto' [RT: 666:666]



$ nipap vrf modify 6:66 set name titi
VRF 'titi' [RT: 6:66] saved.

$ nipap vrf modify  666:666 asuser eric.dechaux set rt 999:666
VRF 'toto' [RT: 999:666] saved.



$ nipap vrf remove 999:666
RT: 999:666
Name: toto
Description: None

WARNING: THIS WILL REMOVE THE VRF INCLUDING ALL ITS ADDRESSES
Do you really want to remove VRF 'toto' [RT: 999:666]? [y/n]: y
VRF 'toto' [RT: 999:666] removed.

$ nipap vrf remove 6:66 asuser eric.dechaux
RT: 6:66
Name: titi
Description: None

WARNING: THIS WILL REMOVE THE VRF INCLUDING ALL ITS ADDRESSES
Do you really want to remove VRF 'titi' [RT: 6:66]? [y/n]: y
VRF 'titi' [RT: 6:66] removed.



$ nipap pool add name wizard
Pool 'wizard' created.

$ nipap pool add name warrior as eric.dechaux
Pool 'warrior' created.



$ nipap pool modify warrior set ipv6_default_prefix_length 128
Pool 'warrior' saved.

$ nipap pool modify warrior as eric.dechaux set ipv4_default_prefix_length 24 
Pool 'warrior' saved.



$ nipap pool resize warrior as eric.dechaux add 172.31.16.0/22 vrf 2885681152:666
Prefix 172.31.16.0/22 in VRF 'TEST-IPMS' [RT: 2885681152:666] added to pool 'warrior'.

$ nipap pool resize warrior remove 172.31.16.0/22 
Prefix 172.31.16.0/22 removed from pool 'warrior'.



$ nipap pool resize warrior add 172.31.16.0/22 vrf 2885681152:666
Prefix 172.31.16.0/22 in VRF 'TEST-IPMS' [RT: 2885681152:666] added to pool 'warrior'.

$ nipap pool resize warrior asuser eric.dechaux remove 172.31.16.0/22
Prefix 172.31.16.0/22 removed from pool 'warrior'.
```
