### PR TITLE
Add new test target to verify NIPAP upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ env:
         - secure: "lxO7SGOLlMu4AldVb0XNViRAPhanleCeIH5BmrhKRMm1k7YnU0WGmfR+1X+m\n7PYI+011vHyVvC/ofbgbbBgqvmbec103ozrrbMCWPm27OCcfjyYJJJtcMLIe\nnD7cQC3u9F0ASxvBBmKIFIKwWPtzDSs4dq3RNfBXkGQc8RsEk1Y="
     matrix:
         # basic build only running nosetests
-        - "PYLINT=false PERFTEST=false"
+        - "PYLINT=false PERFTEST=false UPGRADE=false"
         # build nosetest and then pylint with artifact upload to S3
-        - "PYLINT=true PERFTEST=true"
+        - "PYLINT=true PERFTEST=true UPGRADE=false"
+        # test upgrade by first installing stable package from official repo
+        # and then build and upgrade to new packages
+        - "PYLINT=false PERFTEST=false UPGRADE=true"
 
 virtualenv:
     system_site_packages: true
@@ -27,30 +30,44 @@ before_script:
 
 
 install:
-    # we use our debian repo to get ip4r
+    # add NIPAP official Debian repo and keys, we use it to get ip4r
     - echo "deb http://spritelink.github.io/NIPAP/repos/apt stable main extra" | sudo tee /etc/apt/sources.list.d/nipap.list
+    - wget -O - https://spritelink.github.io/NIPAP/nipap.gpg.key | sudo apt-key add -
     - sudo apt-get update -qq
-    # install dependencies for building packages and build debian packages
-    - sudo apt-get install -qq -y --force-yes devscripts python-docutils
-    - make builddeb
     # install dependencies for installing & running nipap
     - sudo apt-get install -qq -y --force-yes python-pysqlite2 python-psycopg2 python-ipy python-ldap python-docutils postgresql postgresql-9.1-ip4r python-tornado python-flask python-flask-xml-rpc python-flask-compress
+    # install dependencies for building packages and build NIPAP debian packages
+    - sudo apt-get install -qq -y --force-yes devscripts python-docutils
+    # if we are testing the upgrade, first install NIPAP packages from official repo
+    - "if [[ $UPGRADE == true ]]; then sudo apt-get install -qq nipapd nipap-www nipap-cli; fi"
+    # bump version so that we know we are upgrading beyond what is installed
+    - "if [[ $UPGRADE == true ]]; then (echo -e 'Version 9999.9.9\n------------------\n * Test version for Travis-CI automatic upgrade test'; cat NEWS) > NEWS2; mv NEWS2 NEWS; make bumpversion; fi"
+    # populate answers to nipapd package install questions and reconfigure
+    - "if [[ $UPGRADE == true ]]; then echo 'set nipapd/autoconf true' | sudo debconf-communicate; echo 'set nipapd/startup true' | sudo debconf-communicate; echo 'set nipapd/upgrade true' | sudo debconf-communicate; sudo dpkg-reconfigure nipapd; fi"
+    # create local user for unittest and restart
+    - "if [[ $UPGRADE == true ]]; then sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a unittest -p gottatest -n unittest; sudo /etc/init.d/nipapd restart; fi"
+    # if upgrade, add some data to the database that we can verify later
+    - "if [[ $UPGRADE == true ]]; then nosetests tests/upgrade-before.py; fi"
+    # build new NIPAP packages
+    - make builddeb
     # install the newly built nipap packages
     - sudo dpkg -i nipap*.deb python-pynipap*.deb
     # populate answers to nipapd package install questions and reconfigure
     - echo "set nipapd/autoconf true" | sudo debconf-communicate
     - echo "set nipapd/startup true" | sudo debconf-communicate
-    # reconfigure to do bootstrapping of db and stuff
+    # reconfigure to do bootstrapping of db and stuff, unless we are trying
+    # upgrade in which case this will upgrade everything for us
     - sudo dpkg-reconfigure nipapd
     # create local user for unittests
     - sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a unittest -p gottatest -n "User for running unit tests"
     - sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a readonly -p gottatest --readonly -n "Read-only user for running unit tests"
     - sudo /etc/init.d/nipapd restart
-    - cp nipap-cli/nipaprc ~/.nipaprc
-    - sed -i -e 's/username = guest/username = unittest/' -e 's/password = guest/password = gottatest/' ~/.nipaprc
+    - sed -e 's/username = guest/username = unittest/' -e 's/password = guest/password = gottatest/' nipap-cli/nipaprc > ~/.nipaprc
 
 script:
     - cd tests
+    # if upgrade, verify data loaded before upgrade looks correct post upgrade
+    - "if [[ $UPGRADE == true ]]; then nosetests upgrade-after.py; fi"
     - nosetests xmlrpc.py
     - nosetests nipaptest.py
     - nosetests test_cli.py

--- a/tests/upgrade-after.py
+++ b/tests/upgrade-after.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# vim: et :
+
+import logging
+import unittest
+import sys
+sys.path.append('../nipap/')
+
+from nipap.backend import Nipap
+from nipap.authlib import SqliteAuth
+from nipap.nipapconfig import NipapConfig
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+log_format = "%(levelname)-8s %(message)s"
+
+import xmlrpclib
+
+server_url = "http://unittest:gottatest@127.0.0.1:1337/XMLRPC"
+s = xmlrpclib.Server(server_url, allow_none=1);
+
+ad = { 'authoritative_source': 'nipap' }
+
+
+class TestCheckdata(unittest.TestCase):
+    """ Tests the NIPAP XML-RPC daemon
+    """
+    def _mangle_prefix_result(self, res):
+        """ Mangle prefix result for easier testing
+
+            We can never predict the values of things like the ID (okay, that
+            one is actually kind of doable) or the added and last_modified
+            timestamp. This function will make sure the values are present but
+            then strip them to make it easier to test against an expected
+            result.
+        """
+
+        if isinstance(res, list):
+            # res from list_prefix
+            for p in res:
+                self.assertIn('added', p)
+                self.assertIn('last_modified', p)
+                self.assertIn('id', p)
+                del(p['added'])
+                del(p['last_modified'])
+                del(p['id'])
+
+        elif isinstance(res, dict) and 'result' in res:
+            # res from smart search
+            for p in res['result']:
+                self.assertIn('added', p)
+                self.assertIn('last_modified', p)
+                self.assertIn('id', p)
+                del(p['added'])
+                del(p['last_modified'])
+                del(p['id'])
+
+        elif isinstance(res, dict):
+            # just one single prefix
+            self.assertIn('added', res)
+            self.assertIn('last_modified', res)
+            self.assertIn('id', res)
+            del(res['added'])
+            del(res['last_modified'])
+            del(res['id'])
+
+        return res
+
+
+    def test_verify_prefix(self):
+        """ Verify data after upgrade
+        """
+        expected_base = {
+                'alarm_priority': None,
+                'authoritative_source': 'nipap',
+                'comment': None,
+                'country': None,
+                'description': 'test',
+                'display_prefix': '1.3.3.0/24',
+                'external_key': None,
+                'family': 4,
+                'indent': 0,
+                'inherited_tags': [],
+                'monitor': None,
+                'node': None,
+                'order_id': None,
+                'customer_id': None,
+                'pool_name': None,
+                'pool_id': None,
+                'tags': [],
+                'type': 'reservation',
+                'vrf_rt': None,
+                'vrf_id': 0,
+                'vrf_name': 'default',
+                'vlan': None
+            }
+        expected_prefixes = [
+                { 'prefix': '192.168.0.0/16', 'indent': 0, },
+                { 'prefix': '192.168.0.0/20', 'indent': 1, },
+                { 'prefix': '192.168.0.0/24', 'indent': 2, },
+                { 'prefix': '192.168.1.0/24', 'indent': 2, },
+                { 'prefix': '192.168.2.0/24', 'indent': 2, },
+                { 'prefix': '192.168.32.0/20', 'indent': 1 },
+                { 'prefix': '192.168.32.0/24', 'indent': 2 },
+                ]
+        expected = []
+        for p in expected_prefixes:
+            pexp = expected_base.copy()
+            for key in p:
+                pexp[key] = p[key]
+            pexp['display_prefix'] = p['prefix']
+            expected.append(pexp)
+
+        self.maxDiff = None
+        self.assertEqual(expected, self._mangle_prefix_result(s.list_prefix({ 'auth': ad, })))
+
+
+
+
+if __name__ == '__main__':
+
+    # set up logging
+    log = logging.getLogger()
+    logging.basicConfig()
+    log.setLevel(logging.INFO)
+
+    if sys.version_info >= (2,7):
+        unittest.main(verbosity=2)
+    else:
+        unittest.main()

--- a/tests/upgrade-before.py
+++ b/tests/upgrade-before.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+
+import logging
+import unittest
+import sys
+sys.path.insert(0, '..')
+sys.path.insert(0, '../pynipap')
+sys.path.insert(0, '../nipap')
+sys.path.insert(0, '../nipap-cli')
+
+from nipap.backend import Nipap
+from nipap.authlib import SqliteAuth
+from nipap.nipapconfig import NipapConfig
+
+from pynipap import AuthOptions, VRF, Pool, Prefix, NipapNonExistentError, NipapDuplicateError, NipapValueError
+import pynipap
+
+pynipap.xmlrpc_uri = 'http://unittest:gottatest@127.0.0.1:1337'
+o = AuthOptions({
+        'authoritative_source': 'nipap'
+        })
+
+
+class TestHelper:
+
+    @classmethod
+    def clear_database(cls):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+
+        # have to delete hosts before we can delete the rest
+        n._execute("DELETE FROM ip_net_plan WHERE masklen(prefix) = 32")
+        # the rest
+        n._execute("DELETE FROM ip_net_plan")
+        # delete all except for the default VRF with id 0
+        n._execute("DELETE FROM ip_net_vrf WHERE id > 0")
+        # set default info for VRF 0
+        n._execute("UPDATE ip_net_vrf SET name = 'default', description = 'The default VRF, typically the Internet.' WHERE id = 0")
+        n._execute("DELETE FROM ip_net_pool")
+        n._execute("DELETE FROM ip_net_asn")
+
+
+    def add_prefix(self, prefix, type, description, tags=[]):
+        p = Prefix()
+        p.prefix = prefix
+        p.type = type
+        p.description = description
+        p.tags = tags
+        p.save()
+        return p
+
+
+class TestLoad(unittest.TestCase):
+    """ Load some data into the database
+    """
+    def test_load_data(self):
+        """
+        """
+        th = TestHelper()
+        p1 = th.add_prefix('192.168.0.0/16', 'reservation', 'test')
+        p2 = th.add_prefix('192.168.0.0/20', 'reservation', 'test')
+        p3 = th.add_prefix('192.168.0.0/24', 'reservation', 'test')
+        p4 = th.add_prefix('192.168.1.0/24', 'reservation', 'test')
+        p5 = th.add_prefix('192.168.2.0/24', 'reservation', 'test')
+        p6 = th.add_prefix('192.168.32.0/20', 'reservation', 'test')
+        p7 = th.add_prefix('192.168.32.0/24', 'reservation', 'test')
+
+
+
+if __name__ == '__main__':
+
+    # set up logging
+    log = logging.getLogger()
+    logging.basicConfig()
+    log.setLevel(logging.INFO)
+
+    if sys.version_info >= (2,7):
+        unittest.main(verbosity=2)
+    else:
+        unittest.main()
+
+


### PR DESCRIPTION
First install stable version of NIPAP from official debian repo and then
build new version from source to test the upgrade process of NIPAP in
addition to just running the more static tests.

After the first version from the official debian repo has been
installed, the script tests/upgrade-before.py is run to insert some data
into the database. NIPAP is then upgraded to the version built from
source after which tests/upgrade-after.py is run to verify the output.
upgrade-after.py needs to be updated upon database schema changes to
make sure that the correct columns are there as well as the correct
values are set after the upgrade.

To guarantee that an upgrade is always performed, the version number is
faked to 9999.9.9

Fixes #524.
