### PR TITLE
Rework VRF view to allow viewing default VRF

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -573,12 +573,7 @@ def view_vrf(arg, opts):
     """ View a single VRF
     """
 
-    res = VRF.list({ 'rt': arg })
-    if len(res) < 1:
-        print >> sys.stderr, "VRF with [RT: %s] not found." % arg
-        sys.exit(1)
-
-    v = res[0]
+    v = get_vrf(arg, abort=True)
 
     print "-- VRF"
     print "  %-12s : %d" % ("ID", v.id)


### PR DESCRIPTION
By reusing the get_vrf() function we automatically get support to view
the default vrf by matching on RT '-' and 'none'.

Fixes #527.
