### PR TITLE
Add option to disable interactive prompting

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -52,6 +52,7 @@ if __name__ == '__main__':
 
     import optparse
     parser = optparse.OptionParser()
+    parser.add_option("-f", "--force", action="store_true", help="disable interactive prompting of actions")
     parser.add_option("--version", action="store_true", help="display version information and exit")
 
     (options, args) = parser.parse_args()
@@ -79,7 +80,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     try:
-        cmd = Command(nipap_cli.nipap_cli.cmds, sys.argv[1::])
+        cmd = Command(nipap_cli.nipap_cli.cmds, args)
     except (ValueError, CommandError, NipapError) as exc:
         print >> sys.stderr, "Error: %s" % str(exc)
         sys.exit(1)
@@ -91,7 +92,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        cmd.exe(cmd.arg, cmd.exe_options)
+        cmd.exe(cmd.arg, cmd.exe_options, options)
     except KeyboardInterrupt:
         sys.exit(130)
     except (IOError, OSError):


### PR DESCRIPTION
Certain actions, typically removing prefixes, pools or VRFs results in
an interactive prompt to ensure that the user hasn't mistyped anything
and is really sure he wants to perform the action.

There are situations, commonly when scripting, where it would be
beneficial to disable the prompting and instead assume that the user
knows what he is doing. This change introduces the --force option which
allows the user to suppress any interactive prompting.

Fixes #499.
