### PR TITLE
Add user impersonation in CLI via env

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -54,7 +54,11 @@ def setup_connection():
         print >> sys.stderr, "Please define the username, password, hostname and port in your .nipaprc under the section 'global'"
         sys.exit(1)
 
-    ao = pynipap.AuthOptions({'authoritative_source': 'nipap'})
+    ao = pynipap.AuthOptions({
+        'authoritative_source': 'nipap',
+        'username': os.getenv('NIPAP_IMPERSONATE_USERNAME') or os.getenv('USER'),
+        'full_name': os.getenv('NIPAP_IMPERSONATE_FULL_NAME'),
+        })
 
 
 


### PR DESCRIPTION
This is one option of fixing #538. The other potential solution would use regular options (using optparse) instead of environment variables to accomplish the same thing.

This adds the capability to impersonate another user (setting username
and full_name) via the CLI. It accomplishes this by reading the
environment variables NIPAP_IMPERSONATE_USERNAME and
NIPAP_IMPERSONATE_FULL_NAME. Naturally it only works when a user it
trusted.
