### PR TITLE
Rework of debian install scripts

### DIFF
--- a/nipap/debian/nipapd.config
+++ b/nipap/debian/nipapd.config
@@ -17,11 +17,8 @@ CURRENT_DB_VERSION=3
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
-# TODO: will postgresql always be running when this script is run? what happens
-#       if was installed as a dependancy of nipapd, will it already have been
-#       configured or not?
-
 POSTGRES_INSTALLED=0
+POSTGRES_RUNNING=0
 NIPAP_DB_EXISTS=0
 NIPAP_DB_VERSION=0
 
@@ -30,29 +27,43 @@ su postgres -c 'psql --version' > /dev/null 2>&1
 if [ $? -eq 0 ]; then
 	POSTGRES_INSTALLED=1
 
-	# does the NIPAP database exist?
-	if [ "`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { gsub(/^ */, "", $1); gsub(/ *$/, "", $1); print $1 } }'`" = "nipap" ]; then
-		NIPAP_DB_EXISTS=1
+	su postgres -c "psql -c '\l+'" >/dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		POSTGRES_RUNNING=1
+		# does the NIPAP database exist?
+		if [ "`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { gsub(/^ */, "", $1); gsub(/ *$/, "", $1); print $1 } }'`" = "nipap" ]; then
+			NIPAP_DB_EXISTS=1
 
-		# figure out version of db
-		DB_COMMENT=`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { print $9 } }'`
-		echo "$DB_COMMENT" | grep "schema version: [0-9]\+$" > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			# seems to be a DB comment with proper version
-			NIPAP_DB_VERSION=`echo $DB_COMMENT | sed 's/.*schema version: //'`
+			# figure out version of db
+			DB_COMMENT=`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { print $9 } }'`
+			echo "$DB_COMMENT" | grep "schema version: [0-9]\+$" > /dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				# seems to be a DB comment with proper version
+				NIPAP_DB_VERSION=`echo $DB_COMMENT | sed 's/.*schema version: //'`
+			fi
 		fi
 	fi
 fi
 
+# It would be really weird if PostgreSQL wasn't installed
+if [ $POSTGRES_INSTALLED -eq 0 ]; then
+	db_input high nipapd/postgres_not_installed || true
+	db_go
+	exit 
+fi
 
-# TODO: see above TODO regarding state of postgresql installation. Since nipapd
-#		depends on postgresql, can we assume that it will be there once preinst
-#		is being run? If so, if postgresql is not installed at all, we can
-#		still ask about if the user wants to automatically setup the db for
-#		NIPAP as we know postgresql will be installed when nipapd.preinst is
-#		run.
+# It is not uncommon that PostgreSQL has been stopped as part of package
+# upgrades and if nipapd is in the same batch (again rather likely) we wouldn't
+# see PostgreSQL running by the time this script is executed.
+if [ $POSTGRES_RUNNING -eq 0 ]; then
+	db_input high nipapd/postgres_not_running || true
+	db_go
+	exit
+fi
 
-if [ $NIPAP_DB_EXISTS -eq 0 ]; then
+# So if PostgreSQL is running and we have been able to determine that the NIPAP
+# database doesn't exist...
+if [ $POSTGRES_RUNNING -eq 1 -a $NIPAP_DB_EXISTS -eq 0 ]; then
 	# NIPAP DB does not exist, ask to setup
 	db_input high nipapd/autoconf || true
 	db_go
@@ -70,10 +81,6 @@ else
 			# will be cached. Since this is a new upgrade, we should ask again,
 			# thus clear the old answer first.
 
-			# TODO: not good to do db_reset here, it means we cannot configure
-			#       this package using debconf-communicate.. where can we put
-			#       it instead?
-			db_reset nipapd/upgrade
 			db_input high nipapd/upgrade || true
 			db_go
 		fi
@@ -84,7 +91,7 @@ fi
 
 # SQlite upgrade?
 if [ -n "`which nipap-passwd`" ]; then
-	nipap-passwd --latest-version
+	nipap-passwd --latest-version 2>&1 >/dev/null
 	if [ $? -eq 1 ]; then
 		# TODO: not good to do db_reset here, it means we cannot configure this
 		#       package using debconf-communicate.. where can we put it instead?

--- a/nipap/debian/nipapd.postinst
+++ b/nipap/debian/nipapd.postinst
@@ -11,27 +11,32 @@ DB_NAME='nipap'
 
 
 POSTGRES_INSTALLED=0
+POSTGRES_RUNNING=0
 NIPAP_DB_EXISTS=0
 NIPAP_DB_VERSION=0
 
 # the most current DB version and the one that we are about to install
-CURRENT_DB_VERSION=3
+CURRENT_DB_VERSION=4
 
 # determine if postgres is installed
 su postgres -c 'psql --version' > /dev/null 2>&1
 if [ $? -eq 0 ]; then
 	POSTGRES_INSTALLED=1
 
-	# does the NIPAP database exist?
-	if [ "`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { gsub(/^ */, "", $1); gsub(/ *$/, "", $1); print $1 } }'`" = "nipap" ]; then
-		NIPAP_DB_EXISTS=1
+	su postgres -c "psql -c '\l+'" >/dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		POSTGRES_RUNNING=1
+		# does the NIPAP database exist?
+		if [ "`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { gsub(/^ */, "", $1); gsub(/ *$/, "", $1); print $1 } }'`" = "nipap" ]; then
+			NIPAP_DB_EXISTS=1
 
-		# figure out version of db
-		DB_COMMENT=`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { print $9 } }'`
-		echo "$DB_COMMENT" | grep "schema version: [0-9]\+$" > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			# seems to be a DB comment with proper version
-			NIPAP_DB_VERSION=`echo $DB_COMMENT | sed 's/.*schema version: //'`
+			# figure out version of db
+			DB_COMMENT=`su postgres -c "psql -c '\l+'" | awk -F"|" '{ if ($1~/^ *nipap *$/) { print $9 } }'`
+			echo "$DB_COMMENT" | grep "schema version: [0-9]\+$" > /dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				# seems to be a DB comment with proper version
+				NIPAP_DB_VERSION=`echo $DB_COMMENT | sed 's/.*schema version: //'`
+			fi
 		fi
 	fi
 fi
@@ -55,52 +60,72 @@ case "$1" in
 			update-rc.d nipapd remove >/dev/null 2>&1
 		fi
 
-		# if database already exists
-		if [ "$NIPAP_DB_EXISTS" = "1" ]; then
-			# should we do the upgrade dance?
-			db_get nipapd/startup
+		# if database isn't running
+		if [ $POSTGRES_RUNNING -eq 0 ]; then
+			# are we asked to upgrade?
+			db_get nipapd/upgrade
 			if [ "$RET" = "true" ]; then
-				# iterate through and upgrade in steps of one version at a time
-				for FROM_VERSION in `seq ${NIPAP_DB_VERSION} $((${CURRENT_DB_VERSION}-1))`; do
-					TO_VERSION=$((${FROM_VERSION}+1))
-					PSQL_FILE="upgrade-${FROM_VERSION}-${TO_VERSION}.plsql"
-
-					echo -n "Upgrading NIPAP SQL database schema from ${FROM_VERSION} to ${TO_VERSION}, please be patient, this can take a while..."
-					su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/${PSQL_FILE}" postgres >/dev/null 2>&1 && echo "DONE"
-				done
-
-				# load latest NIPAP database functions
-				echo -n "Loading NIPAP SQL database functions..."
-				su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/functions.plsql" postgres >/dev/null 2>&1 && echo "DONE"
+				echo "PostgreSQL is not running. Unable to upgrade the NIPAP database structure." >&2
 			fi
 
-		else
-			# first time setup
+			# are we asked to automagically install?
 			db_get nipapd/autoconf
 			if [ "$RET" = "true" ]; then
-				# setup new user
-				su -c "createuser -S -D -R -w $DB_USER" postgres >/dev/null 2>&1
-				su -c "psql -q -c \"ALTER USER $DB_USER ENCRYPTED PASSWORD '$DB_PASS'\"" postgres >/dev/null 2>&1
-				# create database and install plpgsql
-				su -c "createdb -O $DB_USER $DB_NAME" postgres >/dev/null 2>&1
-				su -c "createlang -d $DB_NAME plpgsql" postgres >/dev/null 2>&1
-				# load ip4r
-				su -c "psql -q -d $DB_NAME -c 'CREATE EXTENSION ip4r'" postgres >/dev/null 2>&1
-				# load NIPAP database structure
-				su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/ip_net.plsql" postgres >/dev/null 2>&1
-				su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/functions.plsql" postgres >/dev/null 2>&1
-
-				# grant necessary privileges on tables, views, sequences and functions to NIPAP db user
-				su -c "psql -q -d $DB_NAME -c 'GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA public TO nipap'" postgres >/dev/null 2>&1
-				su -c "psql -q -d $DB_NAME -c 'GRANT SELECT, USAGE ON ALL SEQUENCES IN SCHEMA public TO nipap'" postgres >/dev/null 2>&1
-				su -c "psql -q -d $DB_NAME -c 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO $DB_USER'" postgres >/dev/null 2>&1
-
-				# update nipap.conf with database credentials
-				cat /etc/nipap/nipap.conf.dist | sed -e "s/#user *= *[^ ]\+/user = nipap/" -e 's/db_host *= *[^ ]\+/db_host = ""/' -e "s/db_user *= *[^ ]\+/db_user = $DB_USER /" -e "s/db_name *= *[^ ]\+/db_name = $DB_NAME /" -e "s/db_pass *= *[^ ]\+/db_pass = $DB_PASS /" > /etc/nipap/nipap.conf
-
+				echo "PostgreSQL is not running. Unable to load the NIPAP database structure." >&2
 			fi
-			# create local auth database
-			nipap-passwd --create-database > /dev/null 2>&1
+
+		else # db is running, let's load some db files or upgrade!
+			# upgrade!
+			if [ $NIPAP_DB_EXISTS -eq 1 ]; then
+				# should we do the upgrade dance?
+				db_get nipapd/upgrade
+				if [ "$RET" = "true" ]; then
+					# iterate through and upgrade in steps of one version at a time
+					for FROM_VERSION in `seq ${NIPAP_DB_VERSION} $((${CURRENT_DB_VERSION}-1))`; do
+						TO_VERSION=$((${FROM_VERSION}+1))
+						PSQL_FILE="upgrade-${FROM_VERSION}-${TO_VERSION}.plsql"
+
+						echo -n "Upgrading NIPAP SQL database schema from ${FROM_VERSION} to ${TO_VERSION}, please be patient, this can take a while..."
+						su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/${PSQL_FILE}" postgres >/dev/null 2>&1 && echo "DONE"
+					done
+
+					# load latest NIPAP database functions
+					echo -n "Loading NIPAP SQL database functions..."
+					su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/functions.plsql" postgres >/dev/null 2>&1 && echo "DONE"
+
+					# reset the DB upgrade question
+					db_reset nipapd/upgrade
+				fi
+
+			else # no db, ie first time install!
+				# first time setup
+				db_get nipapd/autoconf
+				if [ "$RET" = "true" ]; then
+					# setup new user
+					su -c "createuser -S -D -R -w $DB_USER" postgres >/dev/null 2>&1
+					su -c "psql -q -c \"ALTER USER $DB_USER ENCRYPTED PASSWORD '$DB_PASS'\"" postgres >/dev/null 2>&1
+					# create database and install plpgsql
+					su -c "createdb -O $DB_USER $DB_NAME" postgres >/dev/null 2>&1
+					su -c "createlang -d $DB_NAME plpgsql" postgres >/dev/null 2>&1
+					# load ip4r
+					su -c "psql -q -d $DB_NAME -c 'CREATE EXTENSION ip4r'" postgres >/dev/null 2>&1
+					# load NIPAP database structure
+					su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/ip_net.plsql" postgres >/dev/null 2>&1
+					su -c "psql -q -d $DB_NAME -f /usr/share/nipap/sql/functions.plsql" postgres >/dev/null 2>&1
+
+					# grant necessary privileges on tables, views, sequences and functions to NIPAP db user
+					su -c "psql -q -d $DB_NAME -c 'GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA public TO nipap'" postgres >/dev/null 2>&1
+					su -c "psql -q -d $DB_NAME -c 'GRANT SELECT, USAGE ON ALL SEQUENCES IN SCHEMA public TO nipap'" postgres >/dev/null 2>&1
+					su -c "psql -q -d $DB_NAME -c 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO $DB_USER'" postgres >/dev/null 2>&1
+
+					# update nipap.conf with database credentials
+					cat /etc/nipap/nipap.conf.dist | sed -e "s/#user *= *[^ ]\+/user = nipap/" -e 's/db_host *= *[^ ]\+/db_host = ""/' -e "s/db_user *= *[^ ]\+/db_user = $DB_USER /" -e "s/db_name *= *[^ ]\+/db_name = $DB_NAME /" -e "s/db_pass *= *[^ ]\+/db_pass = $DB_PASS /" > /etc/nipap/nipap.conf
+
+				fi
+
+				# create local auth database
+				nipap-passwd --create-database > /dev/null 2>&1
+			fi
 		fi
 
 		# set ownership/permissions on the local auth db

--- a/nipap/debian/nipapd.templates
+++ b/nipap/debian/nipapd.templates
@@ -39,3 +39,21 @@ Description: Upgrade Sqlite database for local auth ?
  You are upgrading from an older version of nipapd and an old version of the
  Sqlite databse for local auth has been found. The installation can try to
  automatically upgrade to the latest version of the database structure.
+
+Template: nipapd/postgres_not_installed
+Type: note
+Description: PostgreSQL is not installed
+ Unable to determine that PostgreSQL is correctly installed. You can try to
+ rerun the configuration of nipapd using 'dpkg-reconfigure nipapd' after you
+ have correctly installed PostgreSQL.
+
+Template: nipapd/postgres_not_running
+Type: note
+Description: PostgreSQL is not running
+ PostgreSQL does not appear to be running and it is thus not possible to
+ determine whether the nipap database structure has already been loaded or if
+ it needs upgrading.
+ .
+ You can either perform any updates to the database structure manually or try
+ to rerun the configuration of nipapd using 'dpkg-reconfigure nipapd' after
+ PostgreSQL has been started again.


### PR DESCRIPTION
This should fix the issues that we've seen with an upgrade of nipapd
leading to a wipe of the configuration. The issue was that the
installation scripts (config & postinst) determined whether it was an
upgrade or fresh installation based on if we could find the 'nipap'
database in PostgreSQL. Along with NIPAP v0.25 a new patch release of
PostgreSQL was released and when debian is upgrading both nipap and
postgresql at the same time it will stop postgresql to perform the
upgrades. Since we relied on postgresql running to determine whether it
was an upgrade or fresh install we would take the wrong decision and
presume it was a fresh install which includes writing a new
configuration with a randomized password and so forth. Chaos ensued.

With this modification we check that Postgres is running before
proceeding which should fix the issue.

Some of the logic has been moved around between the config and postinst
script. In essence, all logic should be kept in the config file while
the actual installation actions are performed in postinst. It's hard to
do this in reality but this is a step in the right direction. Now all
error messages are printed to stderr from postinst instead of using
db_input to display messages which is also the right thing to do.

Fixes #496.
