### PR TITLE
Fix Chart.JS setup for pools

### DIFF
--- a/nipap-www/nipapwww/templates/pool_edit.html
+++ b/nipap-www/nipapwww/templates/pool_edit.html
@@ -332,8 +332,12 @@ data_pool_addresses_v6[0]['value'] = {{c.pool.used_addresses_v6}};
 data_pool_addresses_v6[1]['value'] = {{c.pool.free_addresses_v6}};
 
 var options = { animationSteps : 20, animationEasing: "easeOutQuart" };
+{% if c.pool.member_prefixes_v4 > 0 %}
 var chart_pool_addresses_v4 = new Chart($("#canvas_pool_addresses_v4")[0].getContext("2d")).Doughnut(data_pool_addresses_v4, options);
+{% endif %}
+{% if c.pool.member_prefixes_v6 > 0 %}
 var chart_pool_addresses_v6 = new Chart($("#canvas_pool_addresses_v6")[0].getContext("2d")).Doughnut(data_pool_addresses_v6, options);
+{% endif %}
 
 </script>
 


### PR DESCRIPTION
The canvas is only included if pool has members of given address family
but we always tried to draw to the canvas (which didn't exist if there
were no members). This resulted in a JavaScript error and if the pool
contained IPv6 prefixes but no IPv4 prefixes, the chart for IPv6
wouldn't be drawn. This change fixes that.

I would like to move all of this to JavaScript on the client side
instead of mixing up server side Jinja2 with Javascript, but that will
probably come once we migrate these pages to AngularJS.

Fixes #552.
