### PR TITLE
Fix ambiguous return value for nipap-passwd --latest-version

### DIFF
--- a/nipap/debian/nipapd.config
+++ b/nipap/debian/nipapd.config
@@ -92,7 +92,7 @@ fi
 # SQlite upgrade?
 if [ -n "`which nipap-passwd`" ]; then
 	nipap-passwd --latest-version 2>&1 >/dev/null
-	if [ $? -eq 1 ]; then
+	if [ $? -eq 2 ]; then
 		# TODO: not good to do db_reset here, it means we cannot configure this
 		#       package using debconf-communicate.. where can we put it instead?
 		db_reset nipapd/sqlite_upgrade

--- a/nipap/nipap-passwd
+++ b/nipap/nipap-passwd
@@ -54,10 +54,13 @@ if __name__ == '__main__':
 
     if options.latest_version:
         try:
-            a._latest_db_version()
+            latest = a._latest_db_version()
+            if not latest:
+                print >> sys.stderr, "It seems your Sqlite database for local auth is out of date"
+                print >> sys.stderr, "Please run 'nipap-passwd --upgrade-database' to upgrade your database."
+                sys.exit(2)
         except nipap.authlib.AuthSqliteError, e:
-            print >> sys.stderr, "Problem with Sqlite database for local auth: %s" % e
-            print >> sys.stderr, "Run 'nipap-passwd --upgrade-database' to upgrade your database."
+            print >> sys.stderr, "Error checking version of Sqlite database for local auth: %s" % e
             sys.exit(1)
         print "Sqlite database for local auth is of the latest version."
         sys.exit(0)

--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -406,7 +406,7 @@ class SqliteAuth(BaseAuth):
             try:
                 self._db_curs.execute(sql)
             except:
-                raise AuthSqliteError("No column '%s' on table 'user'." % column)
+                return False
 
         return True
 

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -123,10 +123,13 @@ if __name__ == '__main__':
     from nipap import authlib
     a = authlib.SqliteAuth('local', 'a', 'b', 'c')
     try:
-        a._latest_db_version()
+        latest = a._latest_db_version()
+        if not latest:
+            print >> sys.stderr, "It seems your Sqlite database for local auth is out of date"
+            print >> sys.stderr, "Please run 'nipap-passwd --upgrade-database' to upgrade your database."
+            sys.exit(2)
     except authlib.AuthSqliteError, e:
-        print >> sys.stderr, "Problem with Sqlite database for local auth: %s" % e
-        print >> sys.stderr, "Run 'nipap-passwd --upgrade-database' to upgrade your database."
+        print >> sys.stderr, "Error checking version of Sqlite database for local auth: %s" % e
         sys.exit(1)
 
 


### PR DESCRIPTION
Before, the function in authlib.py to check the sqlite database for latest version simply returned an exception if the db was out of date.

In this approach, the function will return false and nipap-passwd will exit with the code 2. This way nipapd.config does not catch other exceptions (exit code 1) anymore.

Fixes https://github.com/SpriteLink/NIPAP/issues/557
