### PR TITLE
cli: Don't use colon as delimiter in tab completion

### DIFF
--- a/nipap-cli/bash_complete
+++ b/nipap-cli/bash_complete
@@ -1,16 +1,17 @@
 _nipap()
 {
+	local words
 	local cur
 	# set IFS to newline to handle tab completion for entries containing a space
 	local IFS=$'\n'
 
 	COMPREPLY=()
-	cur=${COMP_WORDS[COMP_CWORD]}
+	_get_comp_words_by_ref -n : words cur
 
 	if [[ ${#cur} -eq 0 ]]; then
-		COMPREPLY=( $( helper-nipap ${COMP_WORDS[@]} ''  ) )
+		COMPREPLY=( $( helper-nipap ${words[@]} ''  ) )
 	else
-		COMPREPLY=( $( helper-nipap ${COMP_WORDS[@]} ) )
+		COMPREPLY=( $( helper-nipap ${words[@]} ) )
 	fi
 
 	return;


### PR DESCRIPTION
Some strings (e.g. VRF) use a colon so this character should not be used as a delimiter by bash completion

Fixes https://github.com/SpriteLink/NIPAP/issues/422
Reference: http://stackoverflow.com/questions/10528695/how-to-reset-comp-wordbreaks-without-effecting-other-completion-script
