### PR TITLE
Replace optparse with argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     # populate answers to nipapd package install questions and reconfigure
     - "if [[ $UPGRADE == true ]]; then echo 'set nipapd/autoconf true' | sudo debconf-communicate; echo 'set nipapd/startup true' | sudo debconf-communicate; echo 'set nipapd/upgrade true' | sudo debconf-communicate; sudo dpkg-reconfigure nipapd; fi"
     # create local user for unittest and restart
-    - "if [[ $UPGRADE == true ]]; then sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a unittest -p gottatest -n unittest; sudo /etc/init.d/nipapd restart; fi"
+    - "if [[ $UPGRADE == true ]]; then sudo nipap/nipap-passwd add -u unittest -p gottatest -f /etc/nipap/local_auth.db -n unittest; sudo /etc/init.d/nipapd restart; fi"
     # if upgrade, add some data to the database that we can verify later
     - "if [[ $UPGRADE == true ]]; then nosetests tests/upgrade-before.py; fi"
     # build new NIPAP packages
@@ -59,8 +59,8 @@ install:
     # upgrade in which case this will upgrade everything for us
     - sudo dpkg-reconfigure nipapd
     # create local user for unittests
-    - sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a unittest -p gottatest -n "User for running unit tests"
-    - sudo nipap/nipap-passwd -f /etc/nipap/local_auth.db -a readonly -p gottatest --readonly -n "Read-only user for running unit tests"
+    - sudo nipap/nipap-passwd add -u unittest -p gottatest -f /etc/nipap/local_auth.db -n "User for running unit tests"
+    - sudo nipap/nipap-passwd add -u readonly -p gottatest -f /etc/nipap/local_auth.db --readonly -n "Read-only user for running unit tests"
     - sudo /etc/init.d/nipapd restart
     - sed -e 's/username = guest/username = unittest/' -e 's/password = guest/password = gottatest/' nipap-cli/nipaprc > ~/.nipaprc
 

--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -50,14 +50,13 @@ if __name__ == '__main__':
     nullh = NullHandler()
     logger.addHandler(nullh)
 
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option("-f", "--force", action="store_true", help="disable interactive prompting of actions")
-    parser.add_option("--version", action="store_true", help="display version information and exit")
+    import argparse
+    parser = argparse.ArgumentParser(description='NIPAP command-line client')
+    parser.add_argument("-f", "--force", action="store_true", help="disable interactive prompting of actions")
+    parser.add_argument("--version", action="store_true", help="display version information and exit")
+    args, cmd_args = parser.parse_known_args()
 
-    (options, args) = parser.parse_args()
-
-    if options.version:
+    if args.version:
         import pynipap
         print "nipap CLI client version:", nipap_cli.__version__
         print "pynipap version:", pynipap.__version__
@@ -80,7 +79,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     try:
-        cmd = Command(nipap_cli.nipap_cli.cmds, args)
+        cmd = Command(nipap_cli.nipap_cli.cmds, cmd_args)
     except (ValueError, CommandError, NipapError) as exc:
         print >> sys.stderr, "Error: %s" % str(exc)
         sys.exit(1)
@@ -92,7 +91,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        cmd.exe(cmd.arg, cmd.exe_options, options)
+        cmd.exe(cmd.arg, cmd.exe_options, args)
     except KeyboardInterrupt:
         sys.exit(130)
     except (IOError, OSError):

--- a/nipap-cli/nipap.man.rst
+++ b/nipap-cli/nipap.man.rst
@@ -13,6 +13,7 @@ Synopsis
 Description
 ===========
 **nipap** is the NIPAP command-line client. It connects (over a network or locally) to a NIPAP backend, send requests and displays the results.
+The connection settings are saved in **~/.nipaprc**
 
 **nipap** ships with a bash completion file which greatly simplifies working with **nipap**.
 

--- a/nipap-www/debian/postinst
+++ b/nipap-www/debian/postinst
@@ -31,8 +31,8 @@ if [ "$RET" = "true" ]; then
 	fi
 	# check if $WWW_USER already exists, if not, create it and configure it in
 	# the nipap.conf configuration file, provided that it exists
-	if [ `nipap-passwd -l | awk "{ if (\\$1~/^$WWW_USER$/) { print \\$1 } }" | wc -l` = "0" ]; then
-		nipap-passwd -a $WWW_USER -p $WWW_PASS -n "$WWW_NAME" -t > /dev/null 2>&1
+	if [ `nipap-passwd list | awk "{ if (\\$1~/^$WWW_USER$/) { print \\$1 } }" | wc -l` = "0" ]; then
+		nipap-passwd add -u $WWW_USER -p $WWW_PASS -n "$WWW_NAME" -t > /dev/null 2>&1
 		if [ -e /etc/nipap/nipap.conf ]; then
 			sed -i -e "s/http:\/\/[^:]\+:[^@]\+@/http:\/\/$WWW_USER@local:$WWW_PASS@/" /etc/nipap/nipap.conf
 		fi

--- a/nipap/nipap-passwd
+++ b/nipap/nipap-passwd
@@ -5,7 +5,7 @@
 
 import sys
 import os
-import optparse
+import argparse
 import logging
 
 import nipap.authlib
@@ -13,26 +13,25 @@ from nipap.nipapconfig import NipapConfig, NipapConfigError
 
 if __name__ == '__main__':
 
-    # parse options
-    parser = optparse.OptionParser()
-    parser.add_option('-a', '--add', dest='add_user', type='string', help='add user ADD_USER')
-    parser.add_option('-c', '--config', dest='config', default='/etc/nipap/nipap.conf', type='string',
-            help='read configuration from CONFIG [default:/etc/nipap/nipap.conf]')
-    parser.add_option('--create-database', action='store_true',
+    # parse arguments
+    parser = argparse.ArgumentParser(description='NIPAP User configuration')
+    parser.add_argument('action', metavar='{list, add, delete}', nargs='?', type=str, choices=['list', 'add', 'delete'], help='define an action to execute')
+    parser.add_argument('-u', '--user', dest='user', type=str, help='username')
+    parser.add_argument('-p', '--password', dest='password', type=str, help='set user\'s password to PASSWORD')
+    parser.add_argument('-n', '--name', dest='name', type=str, help='set user\'s name to NAME')
+    parser.add_argument('-t', '--trusted', action='store_true', dest='trusted', default=False, help='mark user as trusted')
+    parser.add_argument('-r', '--readonly', action='store_true', dest='readonly', default=False, help='set user to read only')
+    parser.add_argument('-f', '--file', dest='db_file', type=str, help="database file [default: read from config]")
+    parser.add_argument('-c', '--config', dest='config', default='/etc/nipap/nipap.conf', type=str, help=
+            'read configuration from CONFIG [default:/etc/nipap/nipap.conf]')
+    parser.add_argument('--version', action='version', version='nipap-passwd version %s' % nipap.__version__)
+    parser.add_argument('--latest-version', action='store_true',
+            help='check that the sqlite database is of latest version')
+    parser.add_argument('--create-database', action='store_true',
             help='create SqliteAuth database')
-    parser.add_option('-d', '--delete', dest='delete_user', type='string', help="delete user DELETE_USER")
-    parser.add_option('-f', '--file', dest='db_file', type='string', help="database file [default: read from config]")
-#    parser.add_option('-m', '--modify', dest='modify_user', type='string')
-    parser.add_option('-n', '--name', dest='name', type='string', help='set user\'s name to NAME')
-    parser.add_option('--latest-version', action='store_true',
-            help='check if the sqlite database is of latest version')
-    parser.add_option('-l', '--list', action='store_true', dest='list', help='list users')
-    parser.add_option('-p', '--password', dest='password', type='string', help='set user\'s password to PASSWORD')
-    parser.add_option('-r', '--readonly', action='store_true', dest='readonly', default=False, help='set user to read only')
-    parser.add_option('-t', '--trusted', action='store_true', dest='trusted', default=False, help='mark user as trusted')
-    parser.add_option('--upgrade-database', action='store_true',
+    parser.add_argument('--upgrade-database', action='store_true',
             help='upgrade sqlite database to latest version')
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
     logger = logging.getLogger()
     log_format = "%(levelname)-8s %(message)s"
@@ -42,17 +41,17 @@ if __name__ == '__main__':
     logger.addHandler(log_stream)
 
     try:
-        cfg = NipapConfig(options.config)
+        cfg = NipapConfig(args.config)
     except NipapConfigError, exc:
-        print >> sys.stderr, "The specified configuration file ('" + options.config + "') does not exist"
+        print >> sys.stderr, "The specified configuration file ('" + args.config + "') does not exist"
         sys.exit(1)
 
-    if options.db_file:
-        cfg.set('auth.backends.local', 'db_path', options.db_file)
+    if args.db_file:
+        cfg.set('auth.backends.local', 'db_path', args.db_file)
 
     a = nipap.authlib.SqliteAuth('local', 'a', 'b', 'c')
 
-    if options.latest_version:
+    if args.latest_version:
         try:
             latest = a._latest_db_version()
             if not latest:
@@ -65,42 +64,50 @@ if __name__ == '__main__':
         print "Sqlite database for local auth is of the latest version."
         sys.exit(0)
 
-    if options.create_database:
+    if args.create_database:
         a._create_database()
         sys.exit(0)
 
-    if options.upgrade_database:
+    if args.upgrade_database:
         a._upgrade_database()
         sys.exit(0)
 
-    if options.list:
+    if args.action == 'list':
         # print a nicely formatted list of users
-        header =  "%-20s %-25s %-7s %-7s" % ('username', 'real name', 'trusted', 'read only')
+        header =  "%-20s %-25s %-7s %-7s" % ('username', 'real name', 'trusted', 'read only') 
         print "%s\n%s" % (header,''.join('-' for x in range(len(header))))
         for u in a.list_users():
-            print "%-20s %-25s %-7d %-7d" % (u['username'], u['full_name'], int(u['trusted']), int(u['readonly']))
-
-    elif options.add_user:
-        if not options.password:
+            if not args.user or args.user == u['username']:
+                print "%-20s %-25s %-7d %-7d" % (u['username'], u['full_name'], int(u['trusted']), int(u['readonly'])) 
+    
+    elif args.action == 'add':
+        if not args.user:
+            print "Please specify user with --user"
+            sys.exit(1)
+        if not args.password:
             print "Please specify password with --password"
             sys.exit(1)
-        if not options.name:
+        if not args.name:
             print "Please specify name with --name"
             sys.exit(1)
         try:
-            a.add_user(options.add_user, options.password, options.name, options.trusted, options.readonly)
-            print "Added user %s to database %s" % (options.add_user, cfg.get('auth.backends.local','db_path'))
+            a.add_user(args.user, args.password, args.name, args.trusted, args.readonly)
+            print "Added user %s to database %s" % (args.user, cfg.get('auth.backends.local','db_path'))
         except nipap.authlib.AuthError as exc:
             if str(exc) == 'attempt to write a readonly database':
                 print "You do not have sufficient rights to write to database: %s" % (cfg.get('auth.backends.local','db_path'))
             elif str(exc) == 'column username is not unique':
-                print "Username '%s' already exists in the database: %s " % (options.add_user, cfg.get('auth.backends.local','db_path'))
+                print "Username '%s' already exists in the database: %s " % (args.user, cfg.get('auth.backends.local','db_path'))
             else:
                 print exc
-    elif options.delete_user:
+                    
+    elif args.action == 'delete':
         try:
-            a.remove_user(options.delete_user)
-            print "User %s deleted from database %s" % (options.delete_user, cfg.get('auth.backends.local', 'db_path'))
+            if not args.user:
+                print "Please specify user with --user"
+                sys.exit(1)
+            a.remove_user(args.user)
+            print "User %s deleted from database %s" % (args.user, cfg.get('auth.backends.local', 'db_path'))
         except nipap.authlib.AuthError as exc:
             if str(exc) == 'attempt to write a readonly database':
                 print "You do not have sufficient rights to write to database: %s" % (cfg.get('auth.backends.local','db_path'))

--- a/nipap/nipap-passwd.man.rst
+++ b/nipap/nipap-passwd.man.rst
@@ -7,7 +7,7 @@ change NIPAP user password
 
 Synopsis
 --------
-**nipapd** [option...]
+**nipap-passwd** action [options...]
 
 Description
 -----------
@@ -19,18 +19,21 @@ Options
 -------
 **nipapd-passwd** accepts the following command-line arguments.
 
+ positional arguments:
+    action {list, add, delete}      define an action to execute
+
+ optional arguments:
     -h, --help                      show a help message
-    -a ADD_USER, --add=ADD_USER     add user with username ADD_USER
-    -c CONFIG, --config=CONFIG      read configuration from configuration file CONFIG [default: /etc/nipap/nipap.conf]
-    --create-database               create SqliteAuth database
-    -d DELETE_USER, --delete=DELETE_USER    delete user with username DELETE_USER
-    -f DB_FILE, --file=DB_FILE      database file [default: read from config]
-    -n NAME, --name=NAME            set user's name to NAME
-    --latest-version                check if the sqlite database is of the latest version
-    -l, --list                      list all users
+    -u USER, --user=USER            username
     -p PASSWORD, --password=PASSWORD    set user's password to PASSWORD
-    -r, --readonly                  set usr to read only
+    -n NAME, --name=NAME            set user's name to NAME
     -t, --trusted                   mark user as trusted
+    -r, --readonly                  set user to read only
+    -f DB_FILE, --file=DB_FILE      database file [default: read from config]
+    -c CONFIG, --config=CONFIG      read configuration from configuration file CONFIG [default: /etc/nipap/nipap.conf]
+    --version                       show program's version number and exit
+    --create-database               create SqliteAuth database
+    --latest-version                check if the sqlite database is of the latest version
     --upgrade-database              upgrade Sqlite database to latest version
 
 Copyright

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -4,7 +4,7 @@
 import fcntl
 import logging
 import logging.handlers
-import optparse
+import argparse
 import os
 import sys
 import ConfigParser
@@ -33,20 +33,22 @@ def drop_privileges(uid_name='nobody', gid_name='nogroup'):
 
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser()
-    parser.add_option("-d", "--debug", action="store_true", dest="debug", help="enable debugging")
-    parser.add_option("-f", "--foreground", action="store_true", dest="foreground", help="run in foreground and log to stdout")
-    parser.add_option("-l", "--listen", metavar="ADDRESS", help="listen to IPv4/6 ADDRESS")
-    parser.add_option("-p", "--port", dest="port", type="int", help="listen on TCP port PORT")
-    parser.add_option("-c", "--config", dest="config_file", type="string", default="/etc/nipap/nipap.conf", help="read configuration from file CONFIG_FILE")
-    parser.add_option("-P", "--pid-file", type="string", help="write a PID file to PID_FILE")
-    parser.add_option("--no-pid-file", action="store_true", default=False, help="turn off writing PID file (overrides config file)")
-    parser.add_option("--version", action="store_true", help="display version information and exit")
-    parser.add_option("--db-version", dest="dbversion", action="store_true", help="display database schema version information and exit")
+    parser = argparse.ArgumentParser(description='NIPAP backend server')
+    parser.add_argument('-d', '--debug', action='store_true', dest='debug', help='enable debugging')
+    parser.add_argument('-f', '--foreground', action='store_true', dest='foreground', help='run in foreground and log to stdout')
+    parser.add_argument('-l', '--listen', type=str, metavar='ADDRESS', help='listen to IPv4/6 ADDRESS')
+    parser.add_argument('-p', '--port', dest='port', type=int, help='listen on TCP port PORT')
+    parser.add_argument('-c', '--config', dest='config_file', type=str, default='/etc/nipap/nipap.conf', help='read configuration from file CONFIG_FILE')
+    parser.add_argument('-P', '--pid-file', type=str, help='write a PID file to PID_FILE')
+    parser.add_argument('--no-pid-file', action='store_true', default=False, help='turn off writing PID file (overrides config file)')
+    parser.add_argument('--version', action='store_true', help='display version information and exit')
+    parser.add_argument("--db-version", dest="dbversion", action="store_true", help="display database schema version information and exit")
+    # Arguments overwriting config settings
+    cfg_args = [ 'debug', 'foreground', 'port', 'config_file' ]
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if options.version:
+    if args.version:
         import nipap
         print "nipapd version:", nipap.__version__
         sys.exit(0)
@@ -76,29 +78,26 @@ if __name__ == '__main__':
     }
 
     try:
-        cfg = NipapConfig(options.config_file, default)
+        cfg = NipapConfig(args.config_file, default)
     except NipapConfigError, exc:
-        if options.config_file:
-            print >> sys.stderr, "The specified configuration file ('" + options.config_file + "') does not exist"
+        if args.config_file:
+            print >> sys.stderr, "The specified configuration file ('" + args.config_file + "') does not exist"
             sys.exit(1)
         # if no config file is specified, we'll live with our defaults
 
-    # Go through list of optparse options and set the config object to
+    # Go through list of argparse args and set the config object to
     # their values.
-    for val in parser.option_list:
-
-        if val.dest is None:
-            continue
+    for arg_dest in cfg_args:
         # This is not very pretty... but how can I otherwise access elements
-        # in the options object from variables?
+        # in the args object from variables?
         try:
-            if eval('options.' + val.dest) is None:
+            if eval('args.' + arg_dest) is None:
                 continue
         except AttributeError:
             continue
 
         try:
-            cfg.set('nipapd', val.dest, str(eval("options." + val.dest)))
+            cfg.set('nipapd', arg_dest, str(eval("args." + arg_dest)))
         except ConfigParser.NoSectionError as exc:
             print >> sys.stderr, "The configuration file contains errors:", exc
             sys.exit(1)
@@ -120,7 +119,7 @@ if __name__ == '__main__':
             print >> sys.stderr, "Could not drop privileges to user '%s' and group '%s'" % (run_user, run_group)
             sys.exit(1)
 
-    if options.dbversion:
+    if args.dbversion:
         from nipap.backend import Nipap
         nip = Nipap()
         print "nipap db schema:", nip._get_db_version()
@@ -154,7 +153,7 @@ if __name__ == '__main__':
         ret = nipap.daemon.createDaemon()
 
     # pid file handling
-    if cfg.get('nipapd', 'pid_file') and not options.no_pid_file:
+    if cfg.get('nipapd', 'pid_file') and not args.no_pid_file:
         # need a+ to be able to read PID from file
         try:
             lf = open(cfg.get('nipapd', 'pid_file'), 'a+', 0)


### PR DESCRIPTION
* Since version 2.7 optparse is deprecated and replaced by argparse. This patch replaces optparse in the given files.
* Also added a small note in nipap.man.rst relating to the settings file.
* In the nipap-passwd tool you can now list a specific user (with option -u).