### PR TITLE
Fix exception for _get_db_version

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -670,12 +670,12 @@ class Nipap:
 
         dbname = self._cfg.get('nipapd', 'db_name')
         self._execute("SELECT description FROM pg_shdescription JOIN pg_database ON objoid = pg_database.oid WHERE datname = '%s'" % dbname)
-        comment = self._curs_pg.fetchone()[0]
+        comment = self._curs_pg.fetchone()
         if comment is None:
             raise NipapError("Could not find comment of psql database %s" % dbname)
 
         db_version = None
-        m = re.match('NIPAP database - schema version: ([0-9]+)', comment)
+        m = re.match('NIPAP database - schema version: ([0-9]+)', comment[0])
         if m:
             db_version = int(m.group(1))
         else:


### PR DESCRIPTION
An exception should now be correctly thrown if there is no comment in the database.

Fix for https://github.com/SpriteLink/NIPAP/issues/586
