### PR TITLE
Fix nipapd sqlite file leak

### DIFF
--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -138,6 +138,7 @@ if __name__ == '__main__':
     except authlib.AuthSqliteError, e:
         print >> sys.stderr, "Error checking version of Sqlite database for local auth: %s" % e
         sys.exit(1)
+    del a
 
     #check nipap database schema version
     from nipap.backend import Nipap


### PR DESCRIPTION
Sqlite connection was not properly closed. Additionally, an open instance in the main thread would prevent others from being closed.

Some links that led me to this:
http://stackoverflow.com/questions/10332253/sqlite-persisting-file-handles-in-wal-mode
https://docs.python.org/2/reference/datamodel.html#object.__del__

Part of https://github.com/SpriteLink/NIPAP/issues/485
