### PR TITLE
Replace ldap lib with ldap3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ install:
     - wget -O - https://spritelink.github.io/NIPAP/nipap.gpg.key | sudo apt-key add -
     - sudo apt-get update -qq
     # install dependencies for installing & running nipap
-    - sudo apt-get install -qq -y --force-yes python-pysqlite2 python-psycopg2 python-ipy python-ldap python-docutils postgresql postgresql-9.1-ip4r python-tornado python-flask python-flask-xml-rpc python-flask-compress
+    - sudo apt-get install -qq -y --force-yes python-pysqlite2 python-psycopg2 python-ipy python-docutils postgresql postgresql-9.1-ip4r python-tornado python-flask python-flask-xml-rpc python-flask-compress
+    - sudo pip install python3-ldap
     # install dependencies for building packages and build NIPAP debian packages
     - sudo apt-get install -qq -y --force-yes devscripts python-docutils
     # if we are testing the upgrade, first install NIPAP packages from official repo

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -217,7 +217,7 @@ if on_rtd:
             else:
                 return Mock()
 
-    MOCK_MODULES = ['ldap', 'IPy', 'psycopg2.extras', 'psycopg2']
+    MOCK_MODULES = ['ldap3', 'IPy', 'psycopg2.extras', 'psycopg2']
 
     for mod_name in MOCK_MODULES:
         sys.modules[mod_name] = Mock()

--- a/nipap/debian/control
+++ b/nipap/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.1
 
 Package: nipap-common
 Architecture: all
-Depends: python (>= 2.7), ${misc:Depends}, python-pysqlite2, python-ldap, python-ipy
+Depends: python (>= 2.7), ${misc:Depends}, python-pysqlite2, python-ipy
 Description: Neat IP Address Planner
  The Neat IP Address Planner, NIPAP, is a system built for efficiently managing
  large amounts of IP addresses. This is the common libraries.

--- a/nipap/setup.py
+++ b/nipap/setup.py
@@ -49,7 +49,7 @@ setup(
     url = nipap.__url__,
     packages = ['nipap'],
     keywords = ['nipap'],
-    requires = ['ldap', 'sqlite3', 'IPy', 'psycopg2'],
+    requires = ['ldap3', 'sqlite3', 'IPy', 'psycopg2'],
     data_files = get_data_files(),
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Replace ldap with ldap3 because ldap lib is not py3 compatible.
Functionality is the same.

https://github.com/SpriteLink/NIPAP/issues/604
