### PR TITLE
Show authentication error in web-ui

### DIFF
--- a/nipap-www/nipapwww/controllers/auth.py
+++ b/nipap-www/nipapwww/controllers/auth.py
@@ -37,8 +37,12 @@ class AuthController(BaseController):
         # Verify username and password.
         auth_fact = AuthFactory()
         auth = auth_fact.get_auth(request.params.get('username'), request.params.get('password'), 'nipap')
-        if not auth.authenticate():
-            c.error = 'Invalid username or password'
+        try:
+            if not auth.authenticate():
+                c.error = 'Invalid username or password'
+                return render('login.html')
+        except AuthError as exc:
+            c.error = 'Authentication error: %s' % str(exc)
             return render('login.html')
 
         # Mark user as logged in


### PR DESCRIPTION
Instead of 'Internal Server error', the web-ui should show a better message. Currently this is only the case if the LDAP server is unavailable.

https://github.com/SpriteLink/NIPAP/issues/605