### PR TITLE
Fix shebang lines to call env instead of python directly

### DIFF
--- a/nipap-cli/helper-nipap
+++ b/nipap-cli/helper-nipap
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 """ CLI command completion helper
 

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 """ NIPAP shell command
 
     A shell command to interact with NIPAP.

--- a/nipap-cli/tests/cli-test.py
+++ b/nipap-cli/tests/cli-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Unit tests for the NIPAP CLI parser
 #

--- a/tests/nipapbase.py
+++ b/tests/nipapbase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et :
 
 import logging

--- a/tests/performance/speedtest.py
+++ b/tests/performance/speedtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python
 # vim: et :
 
 import logging

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et ts=4:
 
 import unittest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et :
 
 import logging

--- a/tests/upgrade-after.py
+++ b/tests/upgrade-after.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et :
 #
 # This is run by Travis-CI after an upgrade to verify that the data loaded by

--- a/tests/upgrade-before.py
+++ b/tests/upgrade-before.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # This is run by Travis-CI before an upgrade to load some data into the
 # database. After the upgrade is complete, the data is verified by

--- a/tests/xmlrpc.py
+++ b/tests/xmlrpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et :
 
 #

--- a/utilities/convert.py
+++ b/utilities/convert.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 #
 # Converts schema-based NIPAP database to VRF-based.
 #

--- a/utilities/export-csv.py
+++ b/utilities/export-csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ Example script for CSV export
 
     This script likely need to be modified to meet your needs but can act as a

--- a/utilities/news2dch.py
+++ b/utilities/news2dch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Copy content of NEWS file into dch file.
 

--- a/utilities/text-import.py
+++ b/utilities/text-import.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: et :
 
 import re


### PR DESCRIPTION
Here is the shebang cleanup to increase portability. It fixes all remaining shebangs 
