### PR TITLE
www-ui: Enable node-field for max prefix length

### DIFF
--- a/nipap-www/nipapwww/public/app.js
+++ b/nipap-www/nipapwww/public/app.js
@@ -7,7 +7,8 @@ var nipapApp = angular.module('nipapApp', [
 	'ngTagsInput',
 	'nipapApp.controllers',
 	'nipapApp.directives',
-	'nipapApp.filters'
+	'nipapApp.filters',
+	'nipapApp.services'
 ]);
 
 /*

--- a/nipap-www/nipapwww/public/controllers.js
+++ b/nipap-www/nipapwww/public/controllers.js
@@ -140,10 +140,13 @@ nipapAppControllers.controller('PrefixListController', function ($scope, $modal)
 /*
  * PrefixAddController - Used to add prefixes to NIPAP
  */
-nipapAppControllers.controller('PrefixAddController', function ($scope, $routeParams, $http) {
+nipapAppControllers.controller('PrefixAddController', function ($scope, $routeParams, $http, prefixHelpers) {
 
 	// prefix method is add - used to customize prefix form template
 	$scope.method = 'add';
+
+	// Expose prefixHelpers.maxPreflen to templates
+	$scope.maxPreflen = prefixHelpers.maxPreflen;
 
 	// open up the datepicker
 	$scope.dpOpen = function($event) {
@@ -443,10 +446,13 @@ nipapAppControllers.controller('PrefixAddController', function ($scope, $routePa
 /*
  * PrefixEditController - used to edit prefixes
  */
-nipapAppControllers.controller('PrefixEditController', function ($scope, $routeParams, $http, $filter) {
+nipapAppControllers.controller('PrefixEditController', function ($scope, $routeParams, $http, $filter, prefixHelpers) {
 
 	// Prefix method is edit - used to customize prefix form template
 	$scope.method = 'edit';
+
+	// Expose prefixHelpers.maxPreflen to templates
+	$scope.maxPreflen = prefixHelpers.maxPreflen;
 
 	// The tags-attributes needs to be initialized due to bug,
 	// see https://github.com/mbenford/ngTagsInput/issues/204

--- a/nipap-www/nipapwww/public/services.js
+++ b/nipap-www/nipapwww/public/services.js
@@ -1,0 +1,29 @@
+/*
+ * Services for the NIPAP AngularJS app
+ */
+
+var nipapAppServices = angular.module('nipapApp.services', []);
+
+/*
+ * Service with handy prefix helper functions
+ */
+nipapAppServices.factory('prefixHelpers', function () {
+
+	var serviceInstance = {};
+
+	/*
+	 * Determines whether a prefix has maximum prefix length,
+	 * /32 for IPv4 and /128 for IPv6.
+	 */
+	serviceInstance.maxPreflen = function(prefix) {
+
+		// Check if 'prefix' is a host prefix or not,
+		// see http://jsfiddle.net/AJEzQ/
+		return /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/32)?$|^((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|:)))(\/128)?$/.test(prefix);
+
+	}
+
+	return serviceInstance;
+
+});
+

--- a/nipap-www/nipapwww/public/templates/prefix_form.html
+++ b/nipap-www/nipapwww/public/templates/prefix_form.html
@@ -205,7 +205,7 @@ PREFIX DATA
 							Node
 						</dt>
 						<dd>
-							<input type="text" name="prefix_node" tooltip="Name of the node, typically the hostname or FQDN of the node (router/switch/host) on which the address is configured." ng-model="prefix.node" ng-disabled="prefix.type != 'host'">
+							<input type="text" name="prefix_node" tooltip="Name of the node, typically the hostname or FQDN of the node (router/switch/host) on which the address is configured." ng-model="prefix.node" ng-disabled="prefix.type != 'host' && !maxPreflen(prefix.prefix)">
 						</dd>
 					</dl>
 				</div>

--- a/nipap-www/nipapwww/templates/base.html
+++ b/nipap-www/nipapwww/templates/base.html
@@ -14,6 +14,7 @@
 		<script src="/ui-bootstrap-tpls.js"></script>
 		<script src="/app.js"></script>
 		<script src="/filters.js"></script>
+		<script src="/services.js"></script>
 		<script src="/directives.js"></script>
 		<script src="/controllers.js"></script>
 		<script src="/jquery-1.9.1.min.js"></script>


### PR DESCRIPTION
Re-implementation of functionality missed when rebuilding web UI with
AngularJS. The node field on the add/edit prefix-page should be enabled
when adding a prefix with max prefix length (/32 for IPv4 and /128 for
IPv6), no matter what prefix type has been selected.

I chose to place the code in a service which is injected into the prefix
add and prefix edit controllers.

Fixes #675