### PR TITLE
Fix pynipap status value

### DIFF
--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -981,10 +981,13 @@ class Prefix(Pynipap):
             'alarm_priority': self.alarm_priority,
             'monitor': self.monitor,
             'vlan': self.vlan,
-            'status': self.status,
             'avps': self.avps,
             'expires': self.expires
         }
+
+        if self.status is not None:
+            data['status'] = self.status
+
         for tag_name in self.tags:
             data['tags'].append(tag_name)
 


### PR DESCRIPTION
If status hasn't been set we should default to whatever the backend
thinks ('assigned') but as pynipap used its default value of None, the
backend would try to honour that.

This changes that so we only send the status value to the backend if its
not None.

Fixes #668.