### PR TITLE
www-ui: Make sure VRF field stays populated

### DIFF
--- a/nipap-www/nipapwww/public/directives.js
+++ b/nipap-www/nipapwww/public/directives.js
@@ -106,9 +106,7 @@ nipapAppDirectives.directive('nipapVrfSelector', function ($http, $timeout) {
 			scope.query_string = '';
 			scope.timeout_promise = null;
 			scope.search_result = [];
-			scope.selected_vrf = null;
 			scope.query_id = 0;
-			scope.internal_seleted_vrf = scope.selected_vrf || { 'id': null };
 			scope.popup_open = false;
 
 			/*


### PR DESCRIPTION
Removed a race condition which caused the VRF field on the add prefix
page to be reset when the VRF was set on page load (when adding a prefix
from another prefix or from a pool).

Fixes #673