### PR TITLE
backend: fix error message for empty pool

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -2291,6 +2291,12 @@ class Nipap:
 
             if 'from-pool' in args:
                 from_pool = self._get_pool(auth, args['from-pool'])
+
+                # make sure there are prefixes in pool, if any prefix is present
+                # than the implied-vrf is set, otherwise the pool is empty
+                if from_pool['vrf_id'] is None:
+                    raise NipapInputError('No prefixes in pool')
+
                 # set default type from pool if missing
                 if 'type' not in attr:
                     attr['type'] = from_pool['default_type']


### PR DESCRIPTION
Trying to assign addresses from an empty pool would give a weird error
message ("VRF must be the same as the pools implied VRF"). Since we run
find_free_prefix after we look if the requested VRF is equal to the
pools implied VRF I have introduced a check earlier on in the code to
make sure the implied VRF is set (which means there are prefixes in the
pool). The result is an error message that is much more relatable.

Fixes #685