### PR TITLE
cli: use smart search for VRF listing

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -1958,7 +1958,6 @@ cmds = {
                     'rest_argument': {
                         'type': 'value',
                         'content_type': unicode,
-                        'description': 'Prefix',
                     },
                     'children': {
                         'vrf_rt': {
@@ -2469,50 +2468,8 @@ cmds = {
                     'rest_argument': {
                         'type': 'value',
                         'content_type': unicode,
-                        'description': 'Pool',
                     },
                     'children': {
-                        'default-type': {
-                            'type': 'option',
-                            'argument': {
-                                'type': 'value',
-                                'content_type': unicode,
-                                'descripton': 'Default prefix type: reservation | assignment | host',
-                                'complete': complete_prefix_type,
-                            }
-                        },
-                        'name': {
-                            'type': 'option',
-                            'argument': {
-                                'type': 'value',
-                                'content_type': unicode,
-                                'descripton': 'Name of the pool'
-                            }
-                        },
-                        'description': {
-                            'type': 'option',
-                            'argument': {
-                                'type': 'value',
-                                'content_type': unicode,
-                                'descripton': 'A short description of the pool'
-                            }
-                        },
-                        'ipv4_default_prefix_length': {
-                            'type': 'option',
-                            'argument': {
-                                'type': 'value',
-                                'content_type': int,
-                                'descripton': 'Default IPv4 prefix length'
-                            }
-                        },
-                        'ipv6_default_prefix_length': {
-                            'type': 'option',
-                            'argument': {
-                                'type': 'value',
-                                'content_type': int,
-                                'descripton': 'Default IPv6 prefix length'
-                            }
-                        },
                         'vrf_rt': {
                             'type': 'option',
                             'argument': {

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -1506,18 +1506,18 @@ class TestCli(unittest.TestCase):
 
 
 class TestNipapHelper(unittest.TestCase):
-    """ Test sanity for country value - should be ISO 3166-1 alpha-2 compliant
+    """ Test the nipap helper app
     """
     def test_test1(self):
         from nipap_cli.command import Command, InvalidCommand
         from nipap_cli import nipap_cli
         from pynipap import NipapError
 
-        cmd = Command(nipap_cli.cmds, ['vrf', 'list', 'nam'])
-        self.assertEqual(['name'], sorted(cmd.complete()))
+        cmd = Command(nipap_cli.cmds, ['pool', 'res'])
+        self.assertEqual(['resize'], sorted(cmd.complete()))
 
-        cmd = Command(nipap_cli.cmds, ['vrf', 'list', 'name'])
-        self.assertEqual(['name'], sorted(cmd.complete()))
+        cmd = Command(nipap_cli.cmds, ['pool', 'resize'])
+        self.assertEqual(['resize'], sorted(cmd.complete()))
 
 
 


### PR DESCRIPTION
The 'nipap vrf list ...' command constructed it's own query dict instead
of relying on the smart_search_vrf method of the backend which is weird
and inconsistent as both prefix and pool listing uses the respective
smart_search functions.
