### PR TITLE
www: Fix node input for other allocation methods

### DIFF
--- a/nipap-www/nipapwww/public/controllers.js
+++ b/nipap-www/nipapwww/public/controllers.js
@@ -145,8 +145,8 @@ nipapAppControllers.controller('PrefixAddController', function ($scope, $routePa
 	// prefix method is add - used to customize prefix form template
 	$scope.method = 'add';
 
-	// Expose prefixHelpers.maxPreflen to templates
-	$scope.maxPreflen = prefixHelpers.maxPreflen;
+	// Expose prefixHelpers.enableNodeInput to templates
+	$scope.enableNodeInput = prefixHelpers.enableNodeInput;
 
 	// open up the datepicker
 	$scope.dpOpen = function($event) {
@@ -247,6 +247,7 @@ nipapAppControllers.controller('PrefixAddController', function ($scope, $routePa
 						showDialogNotice('Error', data.message);
 					} else {
 						$scope.from_prefix = data[0];
+						$scope.prefix_family = data[0].family;
 					}
 				})
 				.error(function (data, stat) {
@@ -451,8 +452,8 @@ nipapAppControllers.controller('PrefixEditController', function ($scope, $routeP
 	// Prefix method is edit - used to customize prefix form template
 	$scope.method = 'edit';
 
-	// Expose prefixHelpers.maxPreflen to templates
-	$scope.maxPreflen = prefixHelpers.maxPreflen;
+	// Expose prefixHelpers.enableNodeInput to templates
+	$scope.enableNodeInput = prefixHelpers.enableNodeInput;
 
 	// The tags-attributes needs to be initialized due to bug,
 	// see https://github.com/mbenford/ngTagsInput/issues/204

--- a/nipap-www/nipapwww/public/services.js
+++ b/nipap-www/nipapwww/public/services.js
@@ -12,14 +12,83 @@ nipapAppServices.factory('prefixHelpers', function () {
 	var serviceInstance = {};
 
 	/*
-	 * Determines whether a prefix has maximum prefix length,
+	 * Determines whether a prefix given as a string has maximum prefix length,
 	 * /32 for IPv4 and /128 for IPv6.
 	 */
-	serviceInstance.maxPreflen = function(prefix) {
+	serviceInstance.maxPrefixLength = function(prefix) {
 
 		// Check if 'prefix' is a host prefix or not,
 		// see http://jsfiddle.net/AJEzQ/
 		return /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/32)?$|^((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|:)))(\/128)?$/.test(prefix);
+
+	}
+
+
+	/*
+	 * Determines whether a prefix described from metadata (family and length)
+	 * has maximum prefix length.
+	 */
+	serviceInstance.maxPrefixLengthMeta = function(prefix_family, prefix_length) {
+
+		return (prefix_family == 4 && parseInt(prefix_length) == 32) ||
+			(prefix_family == 6 && parseInt(prefix_length) == 128);
+
+	}
+
+	/*
+	 * Function which determines whether the Node input element should be enabled
+	 * or not. It is only available when the prefix in question is configured as a
+	 * node, ie the prefix is a /32 or /128.
+	 *
+	 * It's called from the prefix add and prefix edit page and as these pages look
+	 * somewhat different we need to account for some stuff.
+	 */
+	serviceInstance.enableNodeInput = function(prefix, alloc_method, prefix_type, prefix_length, prefix_family) {
+
+		/*
+		 * Generally, the node option should only be available for host prefixes.
+		 * However, there is one exception: loopbacks, which are defined as
+		 * assignments with max prefix length.
+		 */
+
+		 // See if prefix type is set
+		 if (prefix_type == 'reservation') {
+
+			// reservation - disable no matter what
+			return false;
+
+		 } else if (prefix_type == 'host') {
+
+			// host - enable no matter what
+			return true;
+
+		 } else if (prefix_type == 'assignment') {
+
+			/*
+			 * Assignment - more tricky case!
+			 *
+			 * If we add a prefix from a pool or other prefix, we use prefix
+			 * length and prefix family to determine if the prefix will have
+			 * max prefix length.  If we add manually, we use a super-regex to
+			 * determine if it is a host prefix directly from the prefix
+			 * string.
+			 */
+			if (alloc_method == 'from-pool' || alloc_method == 'from-prefix') {
+
+				return serviceInstance.maxPrefixLengthMeta(prefix_family, prefix_length);
+
+			} else {
+
+				return serviceInstance.maxPrefixLength(prefix);
+
+			}
+
+		 } else {
+
+			// prefix type not set - disable
+			return false;
+
+		 }
 
 	}
 

--- a/nipap-www/nipapwww/public/templates/prefix_add.html
+++ b/nipap-www/nipapwww/public/templates/prefix_add.html
@@ -99,7 +99,9 @@ FROM-POOL
 						<label for="edit_length_override_radio">Override pools default prefix-length</label>
 						<br/>
 						<div id="length_row" ng-show="pool_use_default_preflen == false">
-							Use prefix-length: <span class="required" tooltip="Pool is missing default prefix length for IPv{{ prefix_family }}, thus is this field required." ng-show="pool_has_default_preflen !== true">*&nbsp;</span><input type="text" size=3 name="prefix_length_pool" ng-model="prefix_length">
+							Use prefix-length:
+							<span class="required" tooltip="Pool is missing default prefix length for IPv{{ prefix_family }}, thus is this field required." ng-show="pool_has_default_preflen !== true">*&nbsp;</span>
+							<input type="text" size=3 name="prefix_length_pool" ng-model="prefix_length">
 						</div>
 					</dd>
 				</dl>

--- a/nipap-www/nipapwww/public/templates/prefix_form.html
+++ b/nipap-www/nipapwww/public/templates/prefix_form.html
@@ -205,7 +205,7 @@ PREFIX DATA
 							Node
 						</dt>
 						<dd>
-							<input type="text" name="prefix_node" tooltip="Name of the node, typically the hostname or FQDN of the node (router/switch/host) on which the address is configured." ng-model="prefix.node" ng-disabled="prefix.type != 'host' && !maxPreflen(prefix.prefix)">
+							<input type="text" name="prefix_node" tooltip="Name of the node, typically the hostname or FQDN of the node (router/switch/host) on which the address is configured." ng-model="prefix.node" ng-disabled="!enableNodeInput(prefix.prefix, prefix_alloc_method, prefix.type, prefix_length, prefix_family)">
 						</dd>
 					</dl>
 				</div>


### PR DESCRIPTION
Fix of the incomplete fix for #675, which did not handle prefixes being
allocated from pools or other prefixes, only manual additions.

Fixes #686