### PR TITLE
www: require prefix field on manual assignment

### DIFF
--- a/nipap-www/nipapwww/public/templates/prefix_form.html
+++ b/nipap-www/nipapwww/public/templates/prefix_form.html
@@ -16,7 +16,7 @@ PREFIX DATA
 							Prefix <span class="required" tooltip="This field is required, please fill in! :-)">*</span>
 						</dt>
 						<dd>
-							<input type="text" name="prefix_prefix" tooltip="The prefix, i.e. 192.0.2.16/28" ng-model="prefix.prefix">
+							<input type="text" name="prefix_prefix" tooltip="The prefix, i.e. 192.0.2.16/28" ng-model="prefix.prefix" ng-required="prefix_alloc_method == 'manual'">
 						</dd>
 					</dl>
 				</div>


### PR DESCRIPTION
The input field has to be filled in when we are manually adding a new
prefix. Since it shouldn't be entered at all for from-pool or
from-prefix operations we use a conditional ng-required statement that
checks that the allocation method is 'manual'.

Fixes #482.