### PR TITLE
cli: fix viewing of pool statistics

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -866,37 +866,65 @@ def view_pool(arg, opts, shell_opts):
 
     # statistics
     print "-- Statistics"
-    # total / used / free prefixes
-    if p.total_prefixes_v4 == 0:
-        used_percent_v4 = 0
-    else:
-        used_percent_v4 = (float(p.used_prefixes_v4)/p.total_prefixes_v4)*100
-    if p.total_prefixes_v6 == 0:
-        used_percent_v6 = 0
-    else:
-        used_percent_v6 = (float(p.used_prefixes_v6)/p.total_prefixes_v6)*100
-    print "  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 prefixes Used / Free",
-            p.used_prefixes_v4, p.free_prefixes_v4, used_percent_v4,
-            p.total_prefixes_v4)
-    print "  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 prefixes Used / Free",
-            p.used_prefixes_v6, p.free_prefixes_v6, used_percent_v6,
-            p.total_prefixes_v6)
 
-    # total / used / free addresses
-    if p.total_addresses_v4 == 0:
-        used_percent_v4 = 0
+    # IPv4 total / used / free prefixes
+    if p.member_prefixes_v4 == 0:
+        print "  IPv4 prefixes Used / Free  : N/A (No IPv4 member prefixes)"
+    elif p.ipv4_default_prefix_length is None:
+        print "  IPv4 prefixes Used / Free  : N/A (IPv4 default prefix length is not set)"
     else:
-        used_percent_v4 = (float(p.used_addresses_v4)/p.total_addresses_v4)*100
-    if p.total_addresses_v6 == 0:
-        used_percent_v6 = 0
+        if p.total_prefixes_v4 == 0:
+            used_percent_v4 = 0
+        else:
+            used_percent_v4 = (float(p.used_prefixes_v4)/p.total_prefixes_v4)*100
+
+        print "  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 prefixes Used / Free",
+                p.used_prefixes_v4, p.free_prefixes_v4, used_percent_v4,
+                p.total_prefixes_v4)
+
+    # IPv6 total / used / free prefixes
+    if p.member_prefixes_v6 == 0:
+        print "  IPv6 prefixes Used / Free  : N/A (No IPv6 member prefixes)"
+    elif p.ipv6_default_prefix_length is None:
+        print "  IPv6 prefixes Used / Free  : N/A (IPv6 default prefix length is not set)"
     else:
-        used_percent_v6 = (float(p.used_addresses_v6)/p.total_addresses_v6)*100
-    print "  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 addresses Used / Free",
-            p.used_addresses_v4, p.free_addresses_v4, used_percent_v4,
-            p.total_addresses_v4)
-    print "  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 addresses Used / Free",
-            p.used_addresses_v6, p.free_addresses_v6, used_percent_v6,
-            p.total_addresses_v6)
+        if p.total_prefixes_v6 == 0:
+            used_percent_v6 = 0
+        else:
+            used_percent_v6 = (float(p.used_prefixes_v6)/p.total_prefixes_v6)*100
+        print "  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 prefixes Used / Free",
+                p.used_prefixes_v6, p.free_prefixes_v6, used_percent_v6,
+                p.total_prefixes_v6)
+
+
+    # IPv4 total / used / free addresses
+    if p.member_prefixes_v4 == 0:
+        print "  IPv4 addresses Used / Free  : N/A (No IPv4 member prefixes)"
+    elif p.ipv4_default_prefix_length is None:
+        print "  IPv4 addresses Used / Free  : N/A (IPv4 default prefix length is not set)"
+    else:
+        if p.total_addresses_v4 == 0:
+            used_percent_v4 = 0
+        else:
+            used_percent_v4 = (float(p.used_addresses_v4)/p.total_addresses_v4)*100
+
+        print "  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 addresses Used / Free",
+                p.used_addresses_v4, p.free_addresses_v4, used_percent_v4,
+                p.total_addresses_v4)
+
+    # IPv6 total / used / free addresses
+    if p.member_prefixes_v6 == 0:
+        print "  IPv6 addresses Used / Free  : N/A (No IPv6 member prefixes)"
+    elif p.ipv6_default_prefix_length is None:
+        print "  IPv6 addresses Used / Free  : N/A (IPv6 default prefix length is not set)"
+    else:
+        if p.total_addresses_v6 == 0:
+            used_percent_v6 = 0
+        else:
+            used_percent_v6 = (float(p.used_addresses_v6)/p.total_addresses_v6)*100
+        print "  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 addresses Used / Free",
+                p.used_addresses_v6, p.free_addresses_v6, used_percent_v6,
+                p.total_addresses_v6)
 
     print "\n-- Prefixes in pool - v4: %d  v6: %d" % (p.member_prefixes_v4,
             p.member_prefixes_v6)


### PR DESCRIPTION
To calculate correct statistics there needs to be at least one member
prefix and the default prefix length need to be set for the address
family in question. When this is not the case, the CLI would throw a
traceback but by adding some checks (similar to the ones in the web UI)
we avoid division by None and instead display a message stating that
statistics aren't available and why.

I've added another issue (#693) to track the issue that the backend
calculates statistics differently for prefixes and addresses.

Fixes #672.