### PR TITLE
Don't use mutable default arguments

### DIFF
--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -124,7 +124,7 @@ class AuthFactory:
 
 
 
-    def get_auth(self, username, password, authoritative_source, auth_options={}):
+    def get_auth(self, username, password, authoritative_source, auth_options=None):
         """ Returns an authentication object.
     
             Examines the auth backend given after the '@' in the username and
@@ -140,6 +140,9 @@ class AuthFactory:
                 A dict which, if authenticated as a trusted user, can override
                 `username` and `authoritative_source`.
         """
+
+        if auth_options is None:
+            auth_options = {}
 
         # validate arguments
         if (authoritative_source is None):
@@ -208,7 +211,7 @@ class BaseAuth:
     _cfg = None
 
 
-    def __init__(self, username, password, authoritative_source, auth_backend, auth_options={}):
+    def __init__(self, username, password, authoritative_source, auth_backend, auth_options=None):
         """ Constructor.
 
             Note that the instance variables not are set by the constructor but
@@ -228,6 +231,9 @@ class BaseAuth:
                 A dict which, if authenticated as a trusted user, can override
                 `username` and `authoritative_source`.
         """
+
+        if auth_options is None:
+            auth_options = {}
 
         self._logger = logging.getLogger(self.__class__.__name__)
         self._cfg = NipapConfig()
@@ -270,7 +276,7 @@ class LdapAuth(BaseAuth):
     _ldap_conn = None
     _authenticated = None
 
-    def __init__(self, name, username, password, authoritative_source, auth_options={}):
+    def __init__(self, name, username, password, authoritative_source, auth_options=None):
         """ Constructor.
 
             Note that the instance variables not are set by the constructor but
@@ -290,6 +296,9 @@ class LdapAuth(BaseAuth):
                 A dict which, if authenticated as a trusted user, can override
                 `username` and `authoritative_source`.
         """
+
+        if auth_options is None:
+            auth_options = {}
 
         BaseAuth.__init__(self, username, password, authoritative_source, name, auth_options)
         self._ldap_uri = self._cfg.get('auth.backends.' + self.auth_backend, 'uri')
@@ -350,7 +359,7 @@ class SqliteAuth(BaseAuth):
     _db_curs = None
     _authenticated = None
 
-    def __init__(self, name, username, password, authoritative_source, auth_options={}):
+    def __init__(self, name, username, password, authoritative_source, auth_options=None):
         """ Constructor.
 
             Note that the instance variables not are set by the constructor but
@@ -372,6 +381,9 @@ class SqliteAuth(BaseAuth):
 
             If the user database and tables are not found, they are created.
         """
+
+        if auth_options is None:
+            auth_options = {}
 
         BaseAuth.__init__(self, username, password, authoritative_source, name, auth_options)
 

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -694,9 +694,13 @@ class Nipap:
 
 
 
-    def _get_query_parts(self, query_str, search_options = {}):
+    def _get_query_parts(self, query_str, search_options=None):
         """ Split a query string into its parts
         """
+
+        if search_options is None:
+            search_options = {}
+
         if query_str is None:
             raise NipapValueError("'query_string' must not be None")
 
@@ -950,7 +954,7 @@ class Nipap:
 
 
 
-    def list_vrf(self, auth, spec = {}):
+    def list_vrf(self, auth, spec=None):
         """ Return a list of VRFs matching `spec`.
 
             * `auth` [BaseAuth]
@@ -960,6 +964,9 @@ class Nipap:
 
             Returns a list of dicts.
         """
+
+        if spec is None:
+            spec = {}
 
         self._logger.debug("list_vrf called; spec: %s" % str(spec))
 
@@ -1074,7 +1081,7 @@ class Nipap:
 
 
 
-    def search_vrf(self, auth, query, search_options = {}):
+    def search_vrf(self, auth, query, search_options=None):
         """ Search VRF list for VRFs matching `query`.
 
             * `auth` [BaseAuth]
@@ -1152,6 +1159,9 @@ class Nipap:
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
         """
 
+        if search_options is None:
+            search_options = {}
+
         #
         # sanitize search options and set default if option missing
         #
@@ -1198,7 +1208,7 @@ class Nipap:
 
 
 
-    def smart_search_vrf(self, auth, query_str, search_options = {}, extra_query = None):
+    def smart_search_vrf(self, auth, query_str, search_options=None, extra_query=None):
         """ Perform a smart search on VRF list.
 
             * `auth` [BaseAuth]
@@ -1234,6 +1244,9 @@ class Nipap:
             See the :func:`search_vrf` function for an explanation of the
             `search_options` argument.
         """
+
+        if search_options is None:
+            search_options = {}
 
         self._logger.debug("smart_search_vrf query string: %s" % query_str)
 
@@ -1524,7 +1537,7 @@ class Nipap:
 
 
 
-    def list_pool(self, auth, spec = {}):
+    def list_pool(self, auth, spec=None):
         """ Return a list of pools.
 
             * `auth` [BaseAuth]
@@ -1534,6 +1547,9 @@ class Nipap:
 
             Returns a list of dicts.
         """
+
+        if spec is None:
+            spec = {}
 
         self._logger.debug("list_pool called; spec: %s" % str(spec))
 
@@ -1590,9 +1606,12 @@ class Nipap:
         return res
 
 
-    def _check_pool_attr(self, attr, req_attr = []):
+    def _check_pool_attr(self, attr, req_attr=None):
         """ Check pool attributes.
         """
+
+        if req_attr is None:
+            req_attr = []
 
         # check attribute names
         allowed_attr = [
@@ -1703,7 +1722,7 @@ class Nipap:
 
 
 
-    def search_pool(self, auth, query, search_options = {}):
+    def search_pool(self, auth, query, search_options=None):
         """ Search pool list for pools matching `query`.
 
             * `auth` [BaseAuth]
@@ -1781,6 +1800,9 @@ class Nipap:
                 * :attr:`offset` - Offset the result list this many pools (default :data:`0`).
         """
 
+        if search_options is None:
+            search_options = {}
+
         #
         # sanitize search options and set default if option missing
         #
@@ -1851,7 +1873,7 @@ class Nipap:
 
 
 
-    def smart_search_pool(self, auth, query_str, search_options = {}, extra_query = None):
+    def smart_search_pool(self, auth, query_str, search_options=None, extra_query=None):
         """ Perform a smart search on pool list.
 
             * `auth` [BaseAuth]
@@ -1886,6 +1908,9 @@ class Nipap:
             See the :func:`search_pool` function for an explanation of the
             `search_options` argument.
         """
+
+        if search_options is None:
+            search_options = {}
 
         self._logger.debug("smart_search_pool query string: %s" % query_str)
 
@@ -2177,7 +2202,7 @@ class Nipap:
 
 
     @requires_rw
-    def add_prefix(self, auth, attr, args = {}):
+    def add_prefix(self, auth, attr, args=None):
         """ Add a prefix and return its ID.
 
             * `auth` [BaseAuth]
@@ -2211,6 +2236,9 @@ class Nipap:
                 documentation for the :func:`find_free_prefix` for a description of how
                 the `args` argument is to be formatted.
         """
+
+        if args is None:
+            args = {}
 
         self._logger.debug("add_prefix called; attr: %s; args: %s" % (str(attr), str(args)))
 
@@ -2848,7 +2876,7 @@ class Nipap:
 
 
 
-    def search_prefix(self, auth, query, search_options = {}):
+    def search_prefix(self, auth, query, search_options=None):
         """ Search prefix list for prefixes matching `query`.
 
             * `auth` [BaseAuth]
@@ -2957,6 +2985,9 @@ class Nipap:
             useful for example when displaying prefixes in a tree without the
             need to implement client side IP address logic.
         """
+
+        if search_options is None:
+            search_options = {}
 
         #
         # sanitize search options and set default if option missing
@@ -3205,7 +3236,7 @@ class Nipap:
 
 
 
-    def smart_search_prefix(self, auth, query_str, search_options = {}, extra_query = None):
+    def smart_search_prefix(self, auth, query_str, search_options=None, extra_query=None):
         """ Perform a smart search on prefix list.
 
             * `auth` [BaseAuth]
@@ -3241,6 +3272,9 @@ class Nipap:
             See the :func:`search_prefix` function for an explanation of the
             `search_options` argument.
         """
+
+        if search_options is None:
+            search_options = {}
 
         self._logger.debug("smart_search_prefix query string: %s" % query_str)
 
@@ -3533,9 +3567,12 @@ class Nipap:
 
 
 
-    def list_asn(self, auth, asn = {}):
+    def list_asn(self, auth, asn=None):
         """ List AS numbers
         """
+
+        if asn is None:
+            asn = {}
 
         self._logger.debug("list_asn called; asn: %s" % str(asn))
 
@@ -3676,7 +3713,7 @@ class Nipap:
 
 
 
-    def search_asn(self, auth, query, search_options = {}):
+    def search_asn(self, auth, query, search_options=None):
         """ Search ASNs for entries matching 'query'
 
             * `auth` [BaseAuth]
@@ -3721,6 +3758,9 @@ class Nipap:
                 * :attr:`max_result` - The maximum number of prefixes to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
         """
+
+        if search_options is None:
+            search_options = {}
 
         #
         # sanitize search options and set default if option missing
@@ -3768,7 +3808,7 @@ class Nipap:
 
 
 
-    def smart_search_asn(self, auth, query_str, search_options = {}, extra_query = None):
+    def smart_search_asn(self, auth, query_str, search_options=None, extra_query=None):
         """ Perform a smart search operation among AS numbers
 
             * `auth` [BaseAuth]
@@ -3800,6 +3840,9 @@ class Nipap:
             See the :func:`search_asn` function for an explanation of the
             `search_options` argument.
         """
+
+        if search_options is None:
+            search_options = {}
 
         self._logger.debug("smart_search_asn called; query_str: %s" % query_str)
 
@@ -3946,7 +3989,7 @@ class Nipap:
 
 
 
-    def search_tag(self, auth, query, search_options = {}):
+    def search_tag(self, auth, query, search_options=None):
         """ Search Tags for entries matching 'query'
 
             * `auth` [BaseAuth]
@@ -3991,6 +4034,9 @@ class Nipap:
                 * :attr:`max_result` - The maximum number of prefixes to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
         """
+
+        if search_options is None:
+            search_options = {}
 
         #
         # sanitize search options and set default if option missing

--- a/nipap/nipap/nipapconfig.py
+++ b/nipap/nipap/nipapconfig.py
@@ -13,11 +13,14 @@ class NipapConfig(ConfigParser.SafeConfigParser):
     _config = None
     _cfg_path = None
 
-    def __init__(self, cfg_path=None, default={}):
+    def __init__(self, cfg_path=None, default=None):
         """ Takes config file path and command line arguments.
         """
 
         self.__dict__ = self.__shared_state
+
+        if default is None:
+            default = {}
 
         if len(self.__shared_state) == 0:
             # First time - create new instance!

--- a/nipap/xmlbench.py
+++ b/nipap/xmlbench.py
@@ -59,7 +59,9 @@ class Request():
 
 
 class Benchmark():
-    def __init__(self, concurrent = 10, total = 100, url = 'http://localhost:7080/XMLRPC', method = 'date', params=[]):
+    def __init__(self, concurrent = 10, total = 100, url = 'http://localhost:7080/XMLRPC', method = 'date', params=None):
+        if params is None:
+            params = {}
         self.url = url
         self.method = method
         self.params = params

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -271,12 +271,16 @@ class Tag(Pynipap):
     """
 
     @classmethod
-    def from_dict(cls, tag = {}):
+    def from_dict(cls, tag=None):
         """ Create new Tag-object from dict.
 
             Suitable for creating objects from XML-RPC data.
             All available keys must exist.
         """
+
+        if tag is None:
+            tag = {}
+
         l = Tag()
         l.name = tag['name']
         return l
@@ -284,9 +288,12 @@ class Tag(Pynipap):
 
 
     @classmethod
-    def search(cls, query, search_opts={}):
+    def search(cls, query, search_opts=None):
         """ Search VRFs.
         """
+
+        if search_opts is None:
+            search_opts = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -355,9 +362,12 @@ class VRF(Pynipap):
 
 
     @classmethod
-    def list(cls, vrf = {}):
+    def list(cls, vrf=None):
         """ List VRFs.
         """
+
+        if vrf is None:
+            vrf = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -434,9 +444,12 @@ class VRF(Pynipap):
 
 
     @classmethod
-    def search(cls, query, search_opts={}):
+    def search(cls, query, search_opts=None):
         """ Search VRFs.
         """
+
+        if search_opts is None:
+            search_opts = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -459,9 +472,12 @@ class VRF(Pynipap):
 
 
     @classmethod
-    def smart_search(cls, query_string, search_options={}, extra_query = None):
+    def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart VRF search.
         """
+
+        if search_options is None:
+            search_options = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -676,9 +692,12 @@ class Pool(Pynipap):
 
 
     @classmethod
-    def search(cls, query, search_opts={}):
+    def search(cls, query, search_opts=None):
         """ Search pools.
         """
+
+        if search_opts is None:
+            search_opts = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -702,9 +721,12 @@ class Pool(Pynipap):
 
 
     @classmethod
-    def smart_search(cls, query_string, search_options={}, extra_query = None):
+    def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart pool search.
         """
+
+        if search_options is None:
+            search_options = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -770,9 +792,12 @@ class Pool(Pynipap):
 
 
     @classmethod
-    def list(self, spec = {}):
+    def list(self, spec=None):
         """ List pools.
         """
+
+        if spec is None:
+            spec = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -887,9 +912,12 @@ class Prefix(Pynipap):
 
 
     @classmethod
-    def search(cls, query, search_opts={}):
+    def search(cls, query, search_opts=None):
         """ Search for prefixes.
         """
+
+        if search_opts is None:
+            search_opts = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -913,9 +941,12 @@ class Prefix(Pynipap):
 
 
     @classmethod
-    def smart_search(cls, query_string, search_options={}, extra_query = None):
+    def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart prefix search.
         """
+
+        if search_options is None:
+            search_options = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -941,9 +972,12 @@ class Prefix(Pynipap):
 
 
     @classmethod
-    def list(cls, spec = {}):
+    def list(cls, spec=None):
         """ List prefixes.
         """
+
+        if spec is None:
+            spec = {}
 
         xmlrpc = XMLRPCConnection()
         try:
@@ -963,9 +997,12 @@ class Prefix(Pynipap):
 
 
 
-    def save(self, args = {}):
+    def save(self, args=None):
         """ Save prefix to NIPAP.
         """
+
+        if args is None:
+            args = {}
 
         xmlrpc = XMLRPCConnection()
         data = {

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -51,7 +51,10 @@ class TestHelper:
         n._execute("DELETE FROM ip_net_asn")
 
 
-    def add_prefix(self, prefix, type, description, tags=[], pool_id=None):
+    def add_prefix(self, prefix, type, description, tags=None, pool_id=None):
+
+        if tags is None:
+            tags = []
 
         p = Prefix()
         p.prefix = prefix

--- a/tests/upgrade-before.py
+++ b/tests/upgrade-before.py
@@ -45,7 +45,9 @@ class TestHelper:
         n._execute("DELETE FROM ip_net_asn")
 
 
-    def add_prefix(self, prefix, type, description, tags=[]):
+    def add_prefix(self, prefix, type, description, tags=None):
+        if tags is None:
+            tags = []
         p = Prefix()
         p.prefix = prefix
         p.type = type


### PR DESCRIPTION
It's generally a bad idea since they are only instantiated once (at declaration time).

An example:
```python
>>> def tst(arg=[]):
...     arg.append(len(arg))
...     print arg
...
>>> tst()
[0]
>>> tst()
[0, 1]
>>> tst()
[0, 1, 2]
``` 