### PR TITLE
backend: late import of ldap module

### DIFF
--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -72,7 +72,6 @@ from nipapconfig import NipapConfig
 
 # Used by auth modules
 import sqlite3
-import ldap
 import string
 import random
 
@@ -305,6 +304,12 @@ class LdapAuth(BaseAuth):
         self._ldap_basedn = self._cfg.get('auth.backends.' + self.auth_backend, 'basedn')
 
         self._logger.debug('Creating LdapAuth instance')
+
+        try:
+            import ldap
+        except ImportError:
+            self._logger.error('Unable to load Python ldap module, please verify it is installed')
+            raise AuthError('Unable to authenticate')
 
         self._logger.debug('LDAP URI: ' + self._ldap_uri)
         self._ldap_conn = ldap.initialize(self._ldap_uri)


### PR DESCRIPTION
This moves the import of the ldap module from the start of nipapd to
when it is actually needed. If LDAP isn't configured as backend
authentication then it will never be used.

If LDAP authentication is enabled but the ldap module is not available,
we will log an error message when someone tries to authenticate. It is
NOT logged on startup of nipapd which might not be completely obvious.
We would need to rework larger parts of the code to achieve that.

Fixes #701.