### PR TITLE
whoisd: add IPv6 support

### DIFF
--- a/whoisd/nipap-whoisd
+++ b/whoisd/nipap-whoisd
@@ -8,6 +8,7 @@ import sys
 
 import ConfigParser
 import SocketServer
+from SocketServer import ForkingMixIn, TCPServer
 
 import nipap_whoisd
 
@@ -54,6 +55,13 @@ def format_vrf(vrf):
     res += format_line('descr', vrf.description)
     return res
 
+
+# monkey patching the ForkingTCPServer for IPv6 support
+class ForkingTCPServer(ForkingMixIn, TCPServer):
+    def server_bind(self):
+        self.socket = socket.socket(socket.AF_INET6, self.socket_type)
+        self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, False)
+        SocketServer.TCPServer.server_bind(self)
 
 
 class WhoisServer(SocketServer.BaseRequestHandler):
@@ -176,10 +184,11 @@ if __name__ == '__main__':
             sys.exit(1)
 
     try:
-        server = SocketServer.ForkingTCPServer((cfg.get('whoisd', 'listen'),
+        server = ForkingTCPServer((cfg.get('whoisd', 'listen'),
             int(cfg.get('whoisd', 'port'))), WhoisServer)
     except socket.error, exc:
         print >> sys.stderr, "Unable to bind to socket", str(exc)
+        sys.exit(1)
 
     # drop privileges
     if cfg.get('whoisd', 'user') is not None:

--- a/whoisd/whoisd.conf.dist
+++ b/whoisd/whoisd.conf.dist
@@ -32,7 +32,10 @@
 user = nobody
 group = nogroup
 
-listen = 0.0.0.0                ; IP address to listen on.
+# listen on all addresses, both IPv4 and IPv6 per default. Note that if you
+# want to listen to an IPv4 address you need to specify it as a IPv4-mapped
+# IPv6 address, ie to listen on 127.0.0.1, specify ::FFFF:127.0.0.1
+listen = ::                     ; IPv6 address to listen on.
 port = 43                       ; XML-RPC listen port (change requires restart)
 pid_file = /var/run/nipap-whoisd/whoisd.pid
 


### PR DESCRIPTION
SocketServer is hard-coded to listen to IPv4 so this introduces some
monkey patching to get around that and enable it for listening on an
IPv6 socket. When binding to "" or :: the server will listen on both
IPv4 and IPv6. To listen on an IPv4 address it needs to be specified as
an IPv4-mapped IPv6 address.

Fixes #718.