### PR TITLE
Improve query interpretation format

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -159,6 +159,31 @@ def _str_to_bool(arg):
 """
     LIST FUNCTIONS
 """
+def _parse_interp_pool(query, indent=1):
+    if 'interpretation' not in query:
+        return
+    interp = query['interpretation']
+    text = None
+    text2 = None
+    if query['operator'] == 'and':
+        text = "AND"
+    elif interp['interpretation'] == 'unclosed quote':
+        text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
+        text2 = "This is not a proper search term as it contains en uneven amount of quotes."
+    elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
+        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
+        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
+    else:
+        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
+    if text:
+        print "%s- %s" % (' '*indent, text)
+    if text2:
+        print "%s   %s" % (' '*indent, text2)
+    if type(query['val1']) is dict:
+        _parse_interp_pool(query['val1'], indent+2)
+    if type(query['val2']) is dict:
+        _parse_interp_pool(query['val2'], indent+2)
+
 
 def list_pool(arg, opts, shell_opts):
     """ List pools matching a search criteria
@@ -187,6 +212,10 @@ def list_pool(arg, opts, shell_opts):
             if len(res['result']) == 0:
                 print "No matching pools found"
                 return
+
+            if shell_opts.show_interpretation:
+                print "Query interpretation:"
+                _parse_interp_pool(res['interpretation'])
 
             print "%-19s %-2s %-39s %-13s  %-8s %s" % (
                 "Name", "#", "Description", "Default type", "4 / 6", "Implied VRF"

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -4,6 +4,7 @@
     A shell command to interact with NIPAP.
 """
 
+#from __future__ import print_function
 
 import ConfigParser
 import csv
@@ -159,14 +160,15 @@ def _str_to_bool(arg):
 """
     LIST FUNCTIONS
 """
-def _parse_interp_pool(query, indent=1):
+def _parse_interp_pool(query, indent=-5, pandop=False):
     if 'interpretation' not in query:
         return
     interp = query['interpretation']
     text = None
     text2 = None
+    andop = False
     if query['operator'] == 'and':
-        text = "AND"
+        andop = True
     elif interp['interpretation'] == 'unclosed quote':
         text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
         text2 = "This is not a proper search term as it contains en uneven amount of quotes."
@@ -176,13 +178,19 @@ def _parse_interp_pool(query, indent=1):
     else:
         text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
     if text:
-        print "%s- %s" % (' '*indent, text)
+        if pandop:
+            a = '     '
+            if indent > 1:
+                a = ' `-- '
+            print "{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text)
+        else:
+            print "%s       `-- %s" % (' '*indent, text)
     if text2:
         print "%s   %s" % (' '*indent, text2)
     if type(query['val1']) is dict:
-        _parse_interp_pool(query['val1'], indent+2)
+        _parse_interp_pool(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
-        _parse_interp_pool(query['val2'], indent+2)
+        _parse_interp_pool(query['val2'], indent+6)
 
 
 def list_pool(arg, opts, shell_opts):
@@ -249,14 +257,15 @@ def list_pool(arg, opts, shell_opts):
         offset += limit
 
 
-def _parse_interp_vrf(query, indent=1):
+def _parse_interp_vrf(query, indent=-5, pandop=False):
     if 'interpretation' not in query:
         return
     interp = query['interpretation']
     text = None
     text2 = None
+    andop = False
     if query['operator'] == 'and':
-        text = "AND"
+        andop = True
     elif interp['interpretation'] == 'unclosed quote':
         text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
         text2 = "This is not a proper search term as it contains en uneven amount of quotes."
@@ -266,13 +275,19 @@ def _parse_interp_vrf(query, indent=1):
     else:
         text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
     if text:
-        print "%s- %s" % (' '*indent, text)
+        if pandop:
+            a = '     '
+            if indent > 1:
+                a = ' `-- '
+            print "{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text)
+        else:
+            print "%s       `-- %s" % (' '*indent, text)
     if text2:
         print "%s   %s" % (' '*indent, text2)
     if type(query['val1']) is dict:
-        _parse_interp_vrf(query['val1'], indent+2)
+        _parse_interp_vrf(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
-        _parse_interp_vrf(query['val2'], indent+2)
+        _parse_interp_vrf(query['val2'], indent+6)
 
 def list_vrf(arg, opts, shell_opts):
     """ List VRFs matching a search criteria
@@ -319,8 +334,9 @@ def _parse_interp_prefix(query, indent=-5, pandop=False):
     interp = query['interpretation']
     text = None
     text2 = None
+    andop = False
     if query['operator'] == 'and':
-        text = "AND"
+        andop = True
     elif interp['interpretation'] == 'unclosed quote':
         text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
         text2 = "This is not a proper search term as it contains en uneven amount of quotes."
@@ -357,13 +373,19 @@ def _parse_interp_prefix(query, indent=-5, pandop=False):
     else:
         text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
     if text:
-        print "%s- %s" % (' '*indent, text)
+        if pandop:
+            a = '     '
+            if indent > 1:
+                a = ' `-- '
+            print "{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text)
+        else:
+            print "%s       `-- %s" % (' '*indent, text)
     if text2:
         print "%s   %s" % (' '*indent, text2)
     if type(query['val1']) is dict:
-        _parse_interp_prefix(query['val1'], indent+2)
+        _parse_interp_prefix(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
-        _parse_interp_prefix(query['val2'], indent+2)
+        _parse_interp_prefix(query['val2'], indent+6)
 
 
 def list_prefix(arg, opts, shell_opts):

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -256,6 +256,58 @@ def list_vrf(arg, opts, shell_opts):
         offset += limit
 
 
+def _parse_interp(query, indent=1):
+    if 'interpretation' not in query:
+        return
+    interp = query['interpretation']
+    text = None
+    text2 = None
+    if query['operator'] == 'and':
+        text = "AND"
+    elif interp['interpretation'] == 'unclosed quote':
+        text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
+        text2 = "This is not a proper search term as it contains en uneven amount of quotes."
+    elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
+        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
+        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
+    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contained_within_equals':
+        if 'strict_prefix' in interp and 'expanded' in interp:
+            text = "%s: %s within %s" % (interp['string'],
+                    interp['interpretation'],
+                    interp['strict_prefix'])
+            text2 = "Prefix must be contained within %s, which is the base prefix of %s (automatically expanded from %s)." % (interp['strict_prefix'], interp['expanded'], interp['string'])
+        elif 'strict_prefix' in interp:
+            text = "%s: %s within %s" % (interp['string'],
+                    interp['interpretation'],
+                    interp['strict_prefix'])
+            text2 = "Prefix must be contained within %s, which is the base prefix of %s." % (interp['strict_prefix'], interp['string'])
+        elif 'expanded' in interp:
+            text = "%s: %s within %s" % (interp['string'],
+                    interp['interpretation'],
+                    interp['expanded'])
+            text2 = "Prefix must be contained within %s (automatically expanded from %s)." % (interp['expanded'], interp['string'])
+        else:
+            text = "%s: %s within %s" % (interp['string'],
+                    interp['interpretation'],
+                    interp['string'])
+            text2 = "Prefix must be contained within %s." % (interp['string'])
+    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
+        text = "%s: Prefix that contains %s" % (interp['string'],
+                interp['string'])
+    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
+        text = "%s: %s equal to %s" % (interp['string'],
+                interp['interpretation'], interp['string'])
+    else:
+        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
+    if text:
+        print "%s- %s" % (' '*indent, text)
+    if text2:
+        print "%s   %s" % (' '*indent, text2)
+    if type(query['val1']) is dict:
+        _parse_interp(query['val1'], indent+2)
+    if type(query['val2']) is dict:
+        _p_interp(query['val2'], indent+2)
+
 
 def list_prefix(arg, opts, shell_opts):
     """ List prefixes matching 'arg'
@@ -296,45 +348,7 @@ def list_prefix(arg, opts, shell_opts):
 
             if shell_opts.show_interpretation:
                 print "Query interpretation:"
-                for interp in res['interpretation']:
-                    text = interp['string']
-                    if interp['interpretation'] == 'unclosed quote':
-                        text = "%s: %s, please close quote!" % (interp['string'], interp['interpretation'])
-                        text2 = "This is not a proper search term as it contains en uneven amount of quotes."
-                    elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-                        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
-                        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
-                    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contained_within_equals':
-                        if 'strict_prefix' in interp and 'expanded' in interp:
-                            text = "%s: %s within %s" % (interp['string'],
-                                    interp['interpretation'],
-                                    interp['strict_prefix'])
-                            text2 = "Prefix must be contained within %s, which is the base prefix of %s (automatically expanded from %s)." % (interp['strict_prefix'], interp['expanded'], interp['string'])
-                        elif 'strict_prefix' in interp:
-                            text = "%s: %s within %s" % (interp['string'],
-                                    interp['interpretation'],
-                                    interp['strict_prefix'])
-                            text2 = "Prefix must be contained within %s, which is the base prefix of %s." % (interp['strict_prefix'], interp['string'])
-                        elif 'expanded' in interp:
-                            text = "%s: %s within %s" % (interp['string'],
-                                    interp['interpretation'],
-                                    interp['expanded'])
-                            text2 = "Prefix must be contained within %s (automatically expanded from %s)." % (interp['expanded'], interp['string'])
-                        else:
-                            text = "%s: %s within %s" % (interp['string'],
-                                    interp['interpretation'],
-                                    interp['string'])
-                            text2 = "Prefix must be contained within %s." % (interp['string'])
-                    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
-                        text = "%s: Prefix that contains %s" % (interp['string'],
-                                interp['string'])
-                    elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
-                        text = "%s: %s equal to %s" % (interp['string'],
-                                interp['interpretation'], interp['string'])
-                    else:
-                        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
-                    print " -", text
-                    print "    ", text2
+                _p_interp(res['interpretation'])
 
             # Guess the width of the prefix column by looking at the initial
             # result set.

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -209,13 +209,13 @@ def list_pool(arg, opts, shell_opts):
     while True:
         res = Pool.smart_search(search_string, { 'offset': offset, 'max_result': limit }, vrf_q)
         if offset == 0: # first time in loop?
-            if len(res['result']) == 0:
-                print "No matching pools found"
-                return
-
             if shell_opts.show_interpretation:
                 print "Query interpretation:"
                 _parse_interp_pool(res['interpretation'])
+
+            if len(res['result']) == 0:
+                print "No matching pools found"
+                return
 
             print "%-19s %-2s %-39s %-13s  %-8s %s" % (
                 "Name", "#", "Description", "Default type", "4 / 6", "Implied VRF"
@@ -287,13 +287,13 @@ def list_vrf(arg, opts, shell_opts):
     while True:
         res = VRF.smart_search(search_string, { 'offset': offset, 'max_result': limit })
         if offset == 0:
-            if len(res['result']) == 0:
-                print "No VRFs matching '%s' found." % search_string
-                return
-
             if shell_opts.show_interpretation:
                 print "Query interpretation:"
                 _parse_interp_vrf(res['interpretation'])
+
+            if len(res['result']) == 0:
+                print "No VRFs matching '%s' found." % search_string
+                return
 
             print "%-16s %-22s %-2s %-40s" % ("VRF RT", "Name", "#", "Description")
             print "--------------------------------------------------------------------------------"
@@ -399,13 +399,13 @@ def list_prefix(arg, opts, shell_opts):
             vrf_q)
 
         if offset == 0: # first time in loop?
-            if len(res['result']) == 0:
-                print "No addresses matching '%s' found." % search_string
-                return
-
             if shell_opts.show_interpretation:
                 print "Query interpretation:"
                 _parse_interp_prefix(res['interpretation'])
+
+            if len(res['result']) == 0:
+                print "No addresses matching '%s' found." % search_string
+                return
 
             # Guess the width of the prefix column by looking at the initial
             # result set.

--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -1144,7 +1144,6 @@ function parseInterp(query, container) {
 			text = "<b>OR</b>";
 		} else if (interp.interpretation == 'and') {
 			text = "<b>AND</b>";
-		} else if (interp.interpretation == 'and') {
 		} else if (interp.interpretation == 'unclosed quote') {
 			text += ', please close quote!';
 			tooltip = 'This is not a proper search term as it contains an uneven amount of quotes.';
@@ -1168,7 +1167,7 @@ function parseInterp(query, container) {
 				tooltip = 'Prefix must be contained within ' + interp.string;
 			}
 		} else if (interp.attribute == 'prefix' && interp.operator == 'contains_equals') {
-			var text = '<b>' + interp.string + ':</b> ' + 'Prefix that contains ' + interp.string;
+			text = '<b>' + interp.string + ':</b> ' + 'Prefix that contains ' + interp.string;
 			tooltip = "The prefix must contain or be equal to " + interp.string;
 		} else if (interp.attribute == 'prefix' && interp.operator == 'equals') {
 			text += ' equal to <b>' + interp.string + '</b>';
@@ -1177,24 +1176,22 @@ function parseInterp(query, container) {
 			text += " matching '<b>" + interp.string + "</b>'";
 			tooltip = "The description OR node OR order id OR the comment should regexp match '" + interp.string + "'";
 		}
-		container.append('<div class="search_interpretation" id="intp" tooltip="' + tooltip + '">' + text + '</div>');
+
 		if (interp.interpretation == 'or' || interp.interpretation == 'and') {
-			container.append('<div class="search_interperation" id="intp_' + container.attr('id') + '_andor" style="margin-left: 20px;"></div>');
-			container = $('#intp_' + container.attr('id') + '_andor');
+			var andor_text = $('<div class="search_interpretation" style="display: inline-block; vertical-align: top;"></div>').appendTo(container);
+			container = $('<div class="search_interpretation" style="display: inline-block;"></div>').appendTo(container);
+			$('<div class="search_interpretation" id="' + container.attr('id') + '_intp" tooltip="' + tooltip + '" style="padding-top: 0.5em; display: inline-block;"><div style="display: inline-block;">' + text + '</div><div style="display: inline-block; border-left:2px solid #666; border-top:2px solid #666; border-bottom:2px solid #666; margin-top: 3px; margin-left: 4px; margin-right: 4px;">&nbsp;</div></div>').appendTo(andor_text);
+		} else {
+			$('<div class="search_interpretation" style="display: block;" id="' + container.attr('id') + '_intp" tooltip="' + tooltip + '">' + text + '</div>').appendTo(container);
 		}
 	}
 
 	if (typeof(query.val1) == 'object') {
-		container.append('<div class="search_interperation" id="intp_' + container.attr('id') + '_val1"></div>');
-		c1 = $('#intp_' + container.attr('id') + '_val1');
-		parseInterp(query.val1, c1);
+		parseInterp(query.val1, container);
 	}
 	if (typeof(query.val2) == 'object') {
-		container.append('<div class="search_interperation" id="intp_' + container.attr('id') + '_val2"></div>');
-		c2 = $('#intp_' + container.attr('id') + '_val2');
-		parseInterp(query.val2, c2);
+		parseInterp(query.val2, container);
 	}
-//	$('#intp' + key).html(text);
 }
 
 

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -3491,8 +3491,8 @@ class Nipap:
             for query_part in query_parts[1:]:
                 query = {
                     'interpretation': {
-                        'interpretation': 'or',
-                        'operator': 'or',
+                        'interpretation': 'and',
+                        'operator': 'and',
                     },
                     'operator': 'and',
                     'val1': query_part,

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -3279,9 +3279,8 @@ class Nipap:
 
         self._logger.debug("smart_search_prefix query string: %s" % query_str)
 
-        # find query parts
         try:
-            query_str_parts = self._get_query_parts(query_str)
+            query, interpretation = self._parse_prefix_query(query_str)
         except NipapValueError:
             return {
                 'interpretation': [
@@ -3294,6 +3293,32 @@ class Nipap:
                 'search_options': search_options,
                 'result': []
             }
+
+        if extra_query is not None:
+            query = {
+                'operator': 'and',
+                'val1': query,
+                'val2': extra_query
+            }
+
+        self._logger.debug("Expanded to: %s" % str(query))
+
+        search_result = self.search_prefix(auth, query, search_options)
+        search_result['interpretation'] = interpretation
+
+        return search_result
+
+
+
+    def _parse_prefix_query(self, query_str):
+        """ Parse a smart search query for prefixes
+
+            This is a helper function to smart_search_prefix for easier unit
+            testing of the parser.
+        """
+
+        # find query parts
+        query_str_parts = self._get_query_parts(query_str)
 
         # go through parts and add to query_parts list
         query_parts = list()
@@ -3451,19 +3476,8 @@ class Nipap:
                     'val2': query
                 }
 
-        if extra_query is not None:
-            query = {
-                'operator': 'and',
-                'val1': query,
-                'val2': extra_query
-            }
+        return query, query_str_parts
 
-        self._logger.debug("Expanded to: %s" % str(query))
-
-        search_result = self.search_prefix(auth, query, search_options)
-        search_result['interpretation'] = query_str_parts
-
-        return search_result
 
 
     #

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -3331,7 +3331,7 @@ class Nipap:
                 query_parts.append({
                     'interpretation': {
                         'string': query_str_part['string'],
-                        'interpretation': '(inherited) tag)',
+                        'interpretation': '(inherited) tag',
                         'attribute': 'tag',
                         'operator': 'equals_any',
                     },

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -1559,12 +1559,19 @@ class TestNipapHelper(unittest.TestCase):
 class TestSmartParser(unittest.TestCase):
     """ Test the smart parsing functions
     """
+    maxDiff = None
 
     def test_test1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
-        query, interp = n._parse_prefix_query('foo')
+        query = n._parse_prefix_query('foo')
         exp_query = {
+                'interpretation': {
+                    'attribute': 'description or comment or node or order_id or customer_id',
+                    'interpretation': 'text',
+                    'operator': 'regex',
+                    'string': 'foo'
+                },
                 'operator': 'or',
                 'val1': {
                     'operator': 'or',
@@ -1609,8 +1616,14 @@ class TestSmartParser(unittest.TestCase):
     def test_test2(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
-        query, interp = n._parse_prefix_query('1.3.3.0/24')
+        query = n._parse_prefix_query('1.3.3.0/24')
         exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv4 prefix',
+                    'operator': 'contained_within_equals',
+                    'string': '1.3.3.0/24'
+                },
                 'operator': 'contained_within_equals',
                 'val1': 'prefix',
                 'val2': '1.3.3.0/24'
@@ -1623,11 +1636,20 @@ class TestSmartParser(unittest.TestCase):
     def test_test3(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
-        query, interp = n._parse_prefix_query('1.3.3.0/24 foo')
-        self.maxDiff = None
+        query = n._parse_prefix_query('1.3.3.0/24 foo')
         exp_query = {
+                'interpretation': {
+                    'interpretation': 'and',
+                    'operator': 'and',
+                },
                 'operator': 'and',
                 'val1': {
+                    'interpretation': {
+                        'attribute': 'description or comment or node or order_id or customer_id',
+                        'interpretation': 'text',
+                        'operator': 'regex',
+                        'string': u'foo'
+                    },
                     'operator': 'or',
                     'val1': {
                         'operator': 'or',
@@ -1665,6 +1687,12 @@ class TestSmartParser(unittest.TestCase):
                         }
                     },
                 'val2': {
+                    'interpretation': {
+                        'attribute': 'prefix',
+                        'interpretation': 'IPv4 prefix',
+                        'operator': 'contained_within_equals',
+                        'string': u'1.3.3.0/24'
+                    },
                     'operator': 'contained_within_equals',
                     'val1': 'prefix',
                     'val2': '1.3.3.0/24'

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -1561,7 +1561,7 @@ class TestSmartParser(unittest.TestCase):
     """
     maxDiff = None
 
-    def test_test1(self):
+    def test_prefix1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
         query = n._parse_prefix_query('foo')
@@ -1613,7 +1613,7 @@ class TestSmartParser(unittest.TestCase):
 
 
 
-    def test_test2(self):
+    def test_prefix2(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
         query = n._parse_prefix_query('1.3.3.0/24')
@@ -1633,7 +1633,7 @@ class TestSmartParser(unittest.TestCase):
 
 
 
-    def test_test3(self):
+    def test_prefix3(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
         query = n._parse_prefix_query('1.3.3.0/24 foo')
@@ -1703,11 +1703,208 @@ class TestSmartParser(unittest.TestCase):
 
 
 
-    def test_test4(self):
+    def test_prefix4(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
         with self.assertRaisesRegexp(nipap.backend.NipapValueError, 'No closing quotation'):
             query, interp = n._parse_prefix_query('"')
+
+
+
+    def test_vrf1(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_vrf_query('foo')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'vrf or name or description',
+                    'interpretation': 'text',
+                    'operator': 'regex',
+                    'string': u'foo'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'or',
+                    'val1': {
+                        'operator': 'regex_match',
+                        'val1': 'name',
+                        'val2': u'foo'
+                        },
+                    'val2': {
+                        'operator': 'regex_match',
+                        'val1': 'description',
+                        'val2': u'foo'
+                        }
+                },
+                'val2': {
+                    'operator': 'regex_match',
+                    'val1': 'rt',
+                    'val2': u'foo'
+                }
+            }
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_vrf2(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_vrf_query('123:456')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'vrf or name or description',
+                    'interpretation': 'text',
+                    'operator': 'regex',
+                    'string': u'123:456'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'or',
+                    'val1': {
+                        'operator': 'regex_match',
+                        'val1': 'name',
+                        'val2': u'123:456'
+                        },
+                    'val2': {
+                        'operator': 'regex_match',
+                        'val1': 'description',
+                        'val2': u'123:456'
+                        }
+                },
+                'val2': {
+                    'operator': 'regex_match',
+                    'val1': 'rt',
+                    'val2': u'123:456'
+                }
+            }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_vrf3(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_vrf_query('#bar')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'tag',
+                    'interpretation': '(inherited) tag',
+                    'operator': 'equals_any',
+                    'string': u'#bar'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'equals_any',
+                    'val1': 'tags',
+                    'val2': u'bar'
+                },
+                'val2': {
+                    'operator': 'equals_any',
+                    'val1': 'inherited_tags',
+                    'val2': u'bar'
+                }
+            }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_vrf4(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        with self.assertRaisesRegexp(nipap.backend.NipapValueError, 'No closing quotation'):
+            query, interp = n._parse_vrf_query('"')
+
+
+
+    def test_pool1(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_pool_query('foo')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'name or description',
+                    'interpretation': 'text',
+                    'operator': 'regex',
+                    'string': u'foo'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'regex_match',
+                    'val1': 'name',
+                    'val2': u'foo'
+                },
+                'val2': {
+                    'operator': 'regex_match',
+                    'val1': 'description',
+                    'val2': u'foo'
+                }
+            }
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_pool2(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_pool_query('123:456')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'name or description',
+                    'interpretation': 'text',
+                    'operator': 'regex',
+                    'string': u'123:456'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'regex_match',
+                    'val1': 'name',
+                    'val2': u'123:456'
+                },
+                'val2': {
+                    'operator': 'regex_match',
+                    'val1': 'description',
+                    'val2': u'123:456'
+                }
+            }
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_pool3(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_pool_query('#bar')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'tag',
+                    'interpretation': '(inherited) tag',
+                    'operator': 'equals_any',
+                    'string': u'#bar'
+                },
+                'operator': 'or',
+                'val1': {
+                    'operator': 'equals_any',
+                    'val1': 'tags',
+                    'val2': u'bar'
+                },
+                'val2': {
+                    'operator': 'equals_any',
+                    'val1': 'inherited_tags',
+                    'val2': u'bar'
+                }
+            }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_pool4(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        with self.assertRaisesRegexp(nipap.backend.NipapValueError, 'No closing quotation'):
+            query, interp = n._parse_pool_query('"')
 
 
 

--- a/tests/xmlrpc.py
+++ b/tests/xmlrpc.py
@@ -1121,9 +1121,49 @@ class NipapXmlTest(unittest.TestCase):
 
         res = s.smart_search_prefix({ 'auth': ad, 'query_string': 'F' })
         expected = {
-                'interpretation': [{'operator': 'regex', 'attribute':
-                    'description or comment or node or order_id or customer_id', 'interpretation':
-                    'text', 'string': 'F'}],
+                'interpretation': {
+                    'interpretation': {
+                        'operator': 'regex',
+                        'attribute': 'description or comment or node or order_id or customer_id',
+                        'interpretation': 'text',
+                        'string': 'F'
+                        },
+                    'operator': 'or',
+                    'val1': {
+                        'operator': 'or',
+                        'val1': {
+                            'operator': 'or',
+                            'val1': {
+                                'operator': 'or',
+                                'val1': {
+                                    'operator': 'regex_match',
+                                    'val1': 'comment',
+                                    'val2': 'F'
+                                },
+                                'val2': {
+                                    'operator': 'regex_match',
+                                    'val1': 'description',
+                                    'val2': 'F'
+                                }
+                            },
+                            'val2': {
+                                'operator': 'regex_match',
+                                'val1': 'node',
+                                'val2': 'F'
+                            }
+                        },
+                        'val2': {
+                            'operator': 'regex_match',
+                            'val1': 'order_id',
+                            'val2': 'F'
+                        }
+                    },
+                    'val2': {
+                        'operator': 'regex_match',
+                        'val1': 'customer_id',
+                        'val2': 'F'
+                    }
+                },
                 'search_options': {'include_all_children':
                 False, 'max_result': 50, 'include_all_parents': False,
                 'parents_depth': 0, 'offset': 0, 'children_depth': 0,
@@ -1270,12 +1310,12 @@ class NipapXmlTest(unittest.TestCase):
         res = s.smart_search_asn({ 'auth': ad, 'query_string': "Autonomous" })
         self.assertEquals(len(res['result']), 1, "search resulted in wrong number of hits")
         self.assertEquals(res['result'][0]['asn'], attr['asn'], "search hit got wrong asn")
-        self.assertEquals(res['interpretation'][0]['attribute'], 'name', "search term interpretated as wrong type")
+        self.assertEquals(res['interpretation']['interpretation']['attribute'], 'name', 'search term interpreted as wrong type')
 
         res = s.smart_search_asn({ 'auth': ad, 'query_string': "5" })
         self.assertEquals(len(res['result']), 1, "search resulted in wrong number of hits")
         self.assertEquals(res['result'][0]['asn'], attr['asn'], "search hit got wrong asn")
-        self.assertEquals(res['interpretation'][0]['attribute'], 'asn', "search term interpretated as wrong type")
+        self.assertEquals(res['interpretation']['interpretation']['attribute'], 'asn', "search term interpretated as wrong type")
 
 
 


### PR DESCRIPTION
This changes the query interpretation format to a new and improved format that is able to correctly model a query. The old format is a list with an entry for each element, which doesn't allow correctly grouping a more complex query.

For example, the query 'a b c' means we have three elements; a, b and c. There is an implicit boolean AND operator between them and so the query interpretation could be correctly represented with just a list and an implicit AND operator. However, as we wish to support a query like 'a AND (b or c)' we now have a different operator and it is (explicitly) grouped in a way that isn't possible to express with a flat list. The new format follows the query format, ie it is a hierarchy and the new query interpretation format can thus express all possible queries.