### PR TITLE
More additional LDAP support

### DIFF
--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -110,6 +110,7 @@ db_path = /etc/nipap/local_auth.db     ; path to SQLite database used
 #
 #basedn = dc=test,dc=com                ; base DN
 #uri = ldaps://ldap.test.com            ; LDAP server URI
+#tls = False                            ; initiate TLS, use ldap://
 #
 # LDAP style
 #binddn_fmt = uid={},dc=test,dc=com


### PR DESCRIPTION
Adds the cacert and tls options to LdapAuth.

cacert should be the full path to the cacert used on the LDAP server
tls should be a truthful value (non-zero) to force TLS

Also fixed a bug with the global name ldap not being available