### PR TITLE
Make "status" action of init scripts LSB compliant

### DIFF
--- a/nipap/debian/nipapd.init
+++ b/nipap/debian/nipapd.init
@@ -114,9 +114,11 @@ case "$1" in
 	status)
 		RUNNING=$(running)
 		if [ -n "$RUNNING" ]; then
-			log_action_msg "NIPAPd XML-RPC server running with PID $RUNNING"
+			log_success_msg "NIPAPd XML-RPC server running with PID $RUNNING"
+			exit 0
 		else
-			log_action_msg "NIPAPd XML-RPC not running"
+			log_failure_msg "NIPAPd XML-RPC not running"
+			exit 3
 		fi
 		;;
 	*)

--- a/whoisd/debian/init
+++ b/whoisd/debian/init
@@ -100,9 +100,11 @@ case "$1" in
 	status)
 		RUNNING=$(running)
 		if [ -n "$RUNNING" ]; then
-			log_action_msg "$LONGNAME running with PID $RUNNING"
+			log_success_msg "$LONGNAME running with PID $RUNNING"
+			exit 0
 		else
-			log_action_msg "$LONGNAME not running"
+			log_failure_msg "$LONGNAME not running"
+			exit 3
 		fi
 		;;
 	*)


### PR DESCRIPTION
Previously, the init scripts would unconditionally return 0 when called
with the "status" action, which misleads (non-human) callers into
believing that the service in question is running even though it is not.
Fix that by explicitly exiting the init script with the appropriate
return code. Also change the slightly improper usage of log_action_msg
with log_success_msg/log_failure_msg.