### PR TITLE
www: fix expires field of infinity

### DIFF
--- a/nipap-www/nipapwww/controllers/xhr.py
+++ b/nipap-www/nipapwww/controllers/xhr.py
@@ -879,6 +879,9 @@ class NipapJSONEncoder(json.JSONEncoder):
 
             vrf_id = obj.vrf.id
             vrf_rt = obj.vrf.rt
+            expires = None
+            if obj.expires is not None:
+                expires = str(obj.expires)
 
             return {
                 'id': obj.id,
@@ -889,7 +892,7 @@ class NipapJSONEncoder(json.JSONEncoder):
                 'display_prefix': obj.display_prefix,
                 'status': obj.status,
                 'description': obj.description,
-                'expires': str(obj.expires),
+                'expires': expires,
                 'comment': obj.comment,
                 'inherited_tags': obj.inherited_tags,
                 'tags': obj.tags,

--- a/nipap-www/nipapwww/public/controllers.js
+++ b/nipap-www/nipapwww/public/controllers.js
@@ -608,8 +608,14 @@ nipapAppControllers.controller('PrefixEditController', function ($scope, $routeP
 		});
 		prefix_data.avps = JSON.stringify(prefix_data.avps);
 
-		// Mangle expires
-		prefix_data.expires = $filter('date')($scope.prefix.expires, 'yyyy-MM-dd HH:mm:ss')
+		// handle null or 'infinity' as.. infinity
+		if ($scope.prefix.expires == null) {
+			// empty string signifies infinity
+			prefix_data.expires = '';
+		} else {
+			// mangle prefix into ISO8601 format
+			prefix_data.expires = $filter('date')($scope.prefix.expires, 'yyyy-MM-dd HH:mm:ss');
+		}
 
 		// Set pool, if any
 		if ($scope.prefix.pool !== null) {


### PR DESCRIPTION
There were two issues surrounding the handling of positive infinite
values for the expires field. Upon reading the values the JSON encoder
would always cast to string which doesn't work very well with None
values as that would be represented as the string "None" rather that
<nil> over the wire and as we use nil for presenting infinity, this
would mess things up. Properly handling this means the text input in the
web form stays empty.

Secondly, we mangle the expires field to format the field into a ISO8601
value before sending to the backend when editing/adding a prefix. We
shouldn't mangle if the expires field is empty, since this means
infinity and mangling it will mess it up.

Fixes #721.