### PR TITLE
Fix updating of the last_modified value

### DIFF
--- a/nipap/sql/triggers.plsql
+++ b/nipap/sql/triggers.plsql
@@ -98,8 +98,8 @@ BEGIN
 		-- update last modified timestamp
 		NEW.last_modified = NOW();
 
-		-- if prefix, type and pool is the same, quick return!
-		IF OLD.type = NEW.type AND OLD.prefix = NEW.prefix AND OLD.pool_id = NEW.pool_id THEN
+		-- if vrf, type and prefix is the same, quick return!
+		IF OLD.vrf_id = NEW.vrf_id AND OLD.type = NEW.type AND OLD.prefix = NEW.prefix THEN
 			RETURN NEW;
 		END IF;
 	END IF;
@@ -860,12 +860,9 @@ CREATE TRIGGER trigger_ip_net_plan__i_before
 
 -- sanity checking of UPDATEs on ip_net_plan
 CREATE TRIGGER trigger_ip_net_plan__vrf_prefix_type__u_before
-	BEFORE UPDATE OF vrf_id, prefix, type
+	BEFORE UPDATE
 	ON ip_net_plan
 	FOR EACH ROW
-	WHEN (OLD.vrf_id != NEW.vrf_id
-		OR OLD.prefix != NEW.prefix
-		OR OLD.type != NEW.type)
 	EXECUTE PROCEDURE tf_ip_net_plan__prefix_iu_before();
 
 -- actions to be performed after an UPDATE on ip_net_plan

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import unittest
 import sys
+import time
 sys.path.insert(0, '..')
 sys.path.insert(0, '../pynipap')
 sys.path.insert(0, '../nipap')
@@ -1487,6 +1488,37 @@ class TestAddressListing(unittest.TestCase):
         for prefix in res['result']:
             result.append(prefix.prefix)
         self.assertEqual(expected, result)
+
+
+
+class TestPrefixLastModified(unittest.TestCase):
+    """ Test updates of the last modified value
+    """
+
+    def setUp(self):
+        """ Test setup, which essentially means to empty the database
+        """
+        TestHelper.clear_database()
+
+    def test1(self):
+        """ The last_modified timestamp should be updated when the prefix is
+            edited
+        """
+        th = TestHelper()
+        p1 = th.add_prefix('1.3.0.0/16', 'reservation', 'test')
+        # make sure added and last_modified are equal
+        self.assertEqual(p1.added, p1.last_modified)
+
+        # this is a bit silly, but as the last_modified time is returned with a
+        # precision of seconds, we need to make sure that we fall on the next
+        # second to actually notice that last_modified is not equal to added
+        time.sleep(1)
+
+        p1.description = 'updated description'
+        p1.save()
+
+        # last_modified should have a later timestamp than added
+        self.assertNotEqual(p1.added, p1.last_modified)
 
 
 


### PR DESCRIPTION
The last_modified value was in fact not updated when modifying a prefix, in most cases at least. This was due to conditions on the trigger that performs the update making it run only when the vrf_id, type or prefix was changed. The conditions themselves are there to increase performance by avoiding to run a large trigger function when it's not necessary.

By moving the conditional part from the trigger definition into the trigger function, the last_modified value can always be updated but the lions share of the function avoided when it is not needed.