### PR TITLE
www: allow deselection of selected pool

### DIFF
--- a/nipap-www/nipapwww/public/directives.js
+++ b/nipap-www/nipapwww/public/directives.js
@@ -80,6 +80,13 @@ nipapAppDirectives.directive('nipapPoolSelectorPopup', function ($http, $timeout
 
 			}
 
+			scope.deselectPool = function (pool) {
+				// deselect pool & close popup
+				scope.selected_pool = null;
+				scope.pools = [];
+				scope.popup_open = false;
+			}
+
 			/*
 			 * Run when popup menu is toggled
 			 */

--- a/nipap-www/nipapwww/public/templates/pool_selector_popup.html
+++ b/nipap-www/nipapwww/public/templates/pool_selector_popup.html
@@ -15,7 +15,7 @@
 					{{ pool.name }}
 				</div>
 				<div class="selector_entry_description">{{ pool.description == null ? '' : pool.description }}</div>
-				<div class="selector_x">
+				<div class="selector_x" ng-click="deselectPool(pool)">
 					<img src="/images/x-mark-3-16.png" ng-show="selected_pool.id == pool.id">
 					<span ng-show="selected_pool.id != pool.id">&nbsp;</span>
 				</div>


### PR DESCRIPTION
When adding a prefix, the pool it is a member of can be specified,
however the page didn't allow you to deselect the pool once it was
selected. That is now fixed.

Fixes #732.