### PR TITLE
www: fix incorrect close of vrf and pool selector

### DIFF
--- a/nipap-www/nipapwww/public/templates/pool_selector_popup.html
+++ b/nipap-www/nipapwww/public/templates/pool_selector_popup.html
@@ -1,4 +1,4 @@
-<div dropdown on-toggle="toggled(open)" is-open="popup_open">
+<div dropdown on-toggle="toggled(open)" is-open="popup_open" ng-click="$event.stopPropagation()">
 	<input type="button" class="btn btn-danger dropdown-toggle" value="Change pool" style="margin-left: 15px;">
 	<div class="dropdown-menu popup_menu selector">
 		<h3>Select pool</h3>

--- a/nipap-www/nipapwww/public/templates/vrf_selector.html
+++ b/nipap-www/nipapwww/public/templates/vrf_selector.html
@@ -1,4 +1,4 @@
-<div dropdown on-toggle="toggled(open)" is-open="popup_open">
+<div dropdown on-toggle="toggled(open)" is-open="popup_open" ng-click="$event.stopPropagation()">
 	<input type="button" class="btn btn-danger dropdown-toggle" name="prefix_vrf_btn" value="Change VRF" style="margin-left: 15px;">
 	<div class="dropdown-menu popup_menu selector" id="vrf_selector_menu">
 		<h3>Select VRF</h3>


### PR DESCRIPTION
The VRF and pool selector would close when clicked on which isn't very
intuitive at all. Found a stackoverflow discussion on this topic:
http://stackoverflow.com/questions/23698316/how-to-prevent-an-angular-bootstrap-dropdown-from-closing-unbind-event-which-wa

This implements that fix for both VRF and pool selector.

Fixes #728.