### PR TITLE
Fix usage of psutil

### DIFF
--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -18,7 +18,7 @@ from tornado.ioloop import IOLoop
 from nipap.nipapconfig import NipapConfig, NipapConfigError
 from nipap.backend import NipapError
 
-import psutil, psutil.error
+import psutil
 import signal
 import atexit
 
@@ -30,7 +30,7 @@ def exit_cleanup():
     # find all our child processes and kill them off
     try:
         p = psutil.Process(os.getpid())
-    except psutil.error.NoSuchProcess:
+    except psutil.NoSuchProcess:
         return
     for pid in p.get_children(recursive=True):
         os.kill(pid.pid, signal.SIGTERM)


### PR DESCRIPTION
Psutil.error is an internal class and shouldn't be referenced from
outside as per https://code.google.com/p/psutil/issues/detail?id=246

Fixes #760