### PR TITLE
cli: accept natural mask for prefix view

### DIFF
--- a/nipap-cli/debian/control
+++ b/nipap-cli/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.1
 
 Package: nipap-cli
 Architecture: all
-Depends: ${misc:Depends}, python (>= 2.4), python-pynipap
+Depends: ${misc:Depends}, python (>= 2.4), python-ipy, python-pynipap
 Description: Neat IP Address Planner
  The Neat IP Address Planner, NIPAP, is a system built for efficiently managing
  large amounts of IP addresses. This is the shell command.

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -981,7 +981,7 @@ def view_prefix(arg, opts, shell_opts):
     try:
         # this fails if bits are set on right side of mask
         ip = IPy.IP(arg)
-    except:
+    except ValueError:
         arg = arg.split('/')[0]
 
     q = { 'prefix': arg }

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -16,6 +16,8 @@ import string
 import subprocess
 import sys
 
+import IPy
+
 import pynipap
 from pynipap import Pool, Prefix, Tag, VRF, NipapError
 from command import Command
@@ -966,6 +968,21 @@ def view_pool(arg, opts, shell_opts):
 def view_prefix(arg, opts, shell_opts):
     """ View a single prefix.
     """
+    # Internally, this function searches in the prefix column which means that
+    # hosts have a prefix length of 32/128 while they are normally displayed
+    # with the prefix length of the network they are in. To allow the user to
+    # input either, e.g. 1.0.0.1 or 1.0.0.1/31 we strip the prefix length bits
+    # to assume /32 if the address is not a network address. If it is the
+    # network address we always search using the specified mask. In certain
+    # cases there is a host with the network address, typically when /31 or /127
+    # prefix lengths are used, for example 1.0.0.0/31 and 1.0.0.0/32 (first host
+    # in /31 network) in which case it becomes necessary to distinguish between
+    # the two using the mask.
+    try:
+        # this fails if bits are set on right side of mask
+        ip = IPy.IP(arg)
+    except:
+        arg = arg.split('/')[0]
 
     q = { 'prefix': arg }
 

--- a/nipap-cli/setup.py
+++ b/nipap-cli/setup.py
@@ -41,9 +41,9 @@ setup(
     author_email = nipap_cli.__author_email__,
     license = nipap_cli.__license__,
     url = nipap_cli.__url__,
-    packages = [ 'nipap_cli', ],
-    keywords = ['nipap_cli', ],
-    requires = ['pynipap', ],
+    packages = ['nipap_cli'],
+    keywords = ['nipap_cli'],
+    requires = ['IPy', 'pynipap'],
     data_files = get_data_files(),
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Previously the view prefix function wouldn't accept the display_prefix,
i.e. a prefix with its natural mask. To show a host prefix it had to be
entered either with a host mask, e.g. /32 or /128 or with no mask at all.

There are scenarios when a host has the network address, most typically
when using /31 or /127 networks. To distinguish between the two, the
mask must be entered, i.e. use /31 to show the network or /32 to show
the host.

Fixes #738.

I did contemplate putting in a warning and/or hint saying that users
need to be careful when using a network address since it could
potentially hide a host prefix but decided not too as ultimately users
should know what they are doing.  I think we should add a section to the
NIPAP user guide CLI section about this thoug.

This also introduces a requirement on IPy for the CLI, which we haven't
had before but I don't think that's a big deal. I've been contemplating
including IPy before anyway, like we could return Pynipap.Prefix.prefix
as a IPy object instead of a text string..

Test runs through despite the lack of IPy in setup.py because IPy is
already installed in Travis-CI as it's required by the backend.
