### PR TITLE
Add scheme to the CLI for HTTPS URI's

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -74,7 +74,11 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # read configuration
-    cfg = ConfigParser.ConfigParser()
+    cfg_defaults = {
+        'scheme': 'http',
+        'port': '1337',
+    }
+    cfg = ConfigParser.ConfigParser(cfg_defaults)
     cfg.read(userrcfile)
     nipap_cli.nipap_cli.cfg = cfg
 

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -48,11 +48,12 @@ def setup_connection():
 
     # build XML-RPC URI
     try:
-        pynipap.xmlrpc_uri = "http://%(username)s:%(password)s@%(hostname)s:%(port)s" % {
+        pynipap.xmlrpc_uri = "%(scheme)s://%(username)s:%(password)s@%(hostname)s:%(port)s" % {
+                'scheme': cfg.get('global', 'scheme'),
                 'username': cfg.get('global', 'username'),
                 'password': cfg.get('global', 'password'),
                 'hostname': cfg.get('global', 'hostname'),
-                'port'    : cfg.get('global', 'port')
+                'port': cfg.get('global', 'port'),
             }
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
         print >> sys.stderr, "Please define the username, password, hostname and port in your .nipaprc under the section 'global'"


### PR DESCRIPTION
The desire was to add https support but since xmlrpc already
supports it, we just increased the options section to
include 'scheme' and added the default to 'http' since we
don't want to break older clients.  Hopefully this change
is transparent and non-breaking.
