### PR TITLE
www: fix debian postinst script

### DIFF
--- a/nipap-www/debian/postinst
+++ b/nipap-www/debian/postinst
@@ -22,8 +22,8 @@ if [ "$RET" = "true" ]; then
 	# check if there is already a www user configured in the
 	# configuration file and use that username for $WWW_USER
 	if [ -e /etc/nipap/nipap.conf ]; then
-		USER=`grep '^xmlrpc_uri' /etc/nipap/nipap.conf | sed 's/^xmlrpc_uri[ \t]*=[ \t]*http:\/\/\(.*\)@[^:]*:.*@.*/\1/'`
-		PASS=`grep '^xmlrpc_uri' /etc/nipap/nipap.conf | sed 's/^xmlrpc_uri[ \t]*=[ \t]*http:\/\/.*@[^:]*:\(.*\)@.*/\1/'`
+		USER=`grep '^xmlrpc_uri' /etc/nipap/nipap.conf | sed 's/^xmlrpc_uri[ \t]*=[ \t]*http:\/\/\(.*\)@\?[^:]*:.*@.*/\1/'`
+		PASS=`grep '^xmlrpc_uri' /etc/nipap/nipap.conf | sed 's/^xmlrpc_uri[ \t]*=[ \t]*http:\/\/.*@\?[^:]*:\(.*\)@.*/\1/'`
 		if [ "$USER" != "" ] && [ "$PASS" != "" ]; then
 			WWW_USER=$USER
 			WWW_PASS=$PASS


### PR DESCRIPTION
The regexp that extracts the username assumed that the username always
contain a '@' character, like web-user@local. It would fail hard if it
didn't.

Fixes #775.