### PR TITLE
cli: add customisable output columns

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -55,6 +55,7 @@ if __name__ == '__main__':
 
     import argparse
     parser = argparse.ArgumentParser(description='NIPAP command-line client')
+    parser.add_argument("-c", "--columns", type=str, help="define columns")
     parser.add_argument("-f", "--force", action="store_true", help="disable interactive prompting of actions")
     parser.add_argument("--show-interpretation", action="store_true", help="show search interpretation")
     parser.add_argument("--version", action="store_true", help="display version information and exit")

--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # read configuration
-    cfg = ConfigParser.ConfigParser()
+    cfg = ConfigParser.ConfigParser({'prefix_list_columns': None })
     cfg.read(userrcfile)
     nipap_cli.nipap_cli.cfg = cfg
 

--- a/nipap-cli/nipaprc
+++ b/nipap-cli/nipaprc
@@ -32,3 +32,16 @@ default_vrf_rt = -
 # VRF RT is specified on the command line.
 # 'all' means that searches will include results from all VRFs
 default_list_vrf_rt = all
+
+# Specify custom columns for 'nipap address list' using a comma separated list
+# of columns. If the list is prefixed with '+' it will add these columns in
+# addition to the standard set of columns.
+#
+# Example to list prefix usage statistics in addition to standard columns:
+#
+#   prefix_list_columns = +total_addresses,used_addresses,free_addresses
+#
+# Example to only listen VRF RT and prefix:
+#
+#   prefix_list_columns = vrf_rt,prefix
+#


### PR DESCRIPTION
The output columns for 'nipap address list' can now be specified with
the -c/--columns paramter, which takes a comma separated list of column
names. To append columns to the default columns, prefix the list with a
"+".

Specify custom columns:

    kll@lingloi320 ~ $ nipap address list -c prefix
    Searching for prefixes in any VRF...
    Prefix
    ===============================
    1.0.0.0/8
      1.0.0.0/16
        1.0.0.0/24
          1.0.0.128/25
    2001:db8:1:1::/64

Append the free_addresses to the default set of columns:

    kll@lingloi320 ~ $ nipap address list -c +used_addresses,free_addresses
    Searching for prefixes in any VRF...
    VRF RT         Prefix                           #  Node   Order ID  Customer ID  Description  Used addresses  Free addresses
    ===================================================================================================================================
    -              1.0.0.0/8                      R #1 None   None      None         foobar       65536           16711680
    -                1.0.0.0/16                   R -  None   None      None         foobar       256             65280
    -                  1.0.0.0/24                 R -  None   None      None         foobar       128             128
    -                    1.0.0.128/25             A -  None   None      None         test         0               128
    -              2001:db8:1:1::/64              R -  None   None      None         test         0               18446744073709551616

In addition, the column width is now dynamic for the majority of
columns. The exceptions are columns that have a more "complicated"
value, like pool_name which is p.pool.name.

Fixes #684.

@garberg, I don't want you to merge this yet.. I'm just looking for
feedback. Please regard this as material for discussion.  The patch
feels kind of convoluted and I'm not particularly happy about the
code.. yet it does what it should :P

So after removing a bunch of lists in my recent PR for #781 I am now
introducing a list of columns, although this time on the client side..
but with reference to our offline discussion, do you see how using
pynipap on both client side and server could potentially save us a few
lines of code!?

I'm not sure if doing getattr in this fashion is a good idea or not...
can't access things like p.vrf.rt, or at least I don't know how!?
