### PR TITLE
authlib: Separate LDAP search credentials

### DIFF
--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -122,6 +122,23 @@ db_path = /etc/nipap/local_auth.db     ; path to SQLite database used
 #
 # {} in binddn_fmt is replaced by the username of the authenticating user.
 #
+## Secondary LDAP connection
+# Normally a bind to the LDAP server is performed using the credentials of the
+# user that is trying to login. A successful bind means that the user has the
+# correct credentials. This LDAP connection is then used to perform a search
+# query fetching the full name ("cn") and potentially the group membership of
+# the user ("memberOf").
+#
+# Depending on the access control configuration of the LDAP server, users may
+# or may not have privileges to perform this search. The following two options,
+# search_binddn and search_password, can be used to create a second LDAP
+# connection that is used to fetch the full name and group memberships in case
+# the user doesn't have sufficient privileges. A second user needs to be
+# created in LDAP for NIPAP that has sufficient privileges to read the "cn" and
+# "memberOf" attribute.
+#search_binddn = uid=foo,ou=Users,dc=example,dc=com
+#search_password = secret
+#
 ## Group permissions
 # Group permissions enables granting read-write or read-only privileges based
 # on a users group membership in LDAP.


### PR DESCRIPTION
Added functionality to allow NIPAP administrators to specify separate
LDAP credentials used when performing the LDAP search for the user
logging in. This is needed for LDAP setups where ordinary user accounts
are not permitted to search the LDAP database.

The search for the user logging in is performed after the user has been
authenticated to get full name and permissions (if used).

Fixes #794