### PR TITLE
Unicode support for whoisd

### DIFF
--- a/whoisd/nipap-whoisd
+++ b/whoisd/nipap-whoisd
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+
 import fcntl
 import os
 import re
@@ -77,6 +79,10 @@ class WhoisServer(SocketServer.BaseRequestHandler):
                 break
 
         query = query.strip()
+        try:
+            query = query.decode("idna")
+        except:
+            pass
 
         # respond!
         total_hits = 0
@@ -128,7 +134,7 @@ class WhoisServer(SocketServer.BaseRequestHandler):
             response += '%\n'
 
         response += "\n%% This query was served by the NIPAP whois server version %s\n" % nipap_whoisd.__version__
-        self.request.send(response)
+        self.request.send(response.encode("utf-8"))
 
 
 

--- a/whoisd/nipap-whoisd
+++ b/whoisd/nipap-whoisd
@@ -66,19 +66,13 @@ class ForkingTCPServer(ForkingMixIn, TCPServer):
         SocketServer.TCPServer.server_bind(self)
 
 
-class WhoisServer(SocketServer.BaseRequestHandler):
+class WhoisServer(SocketServer.StreamRequestHandler):
     def handle(self):
         """ Called for every connection
         """
         # receive data
-        query = ''
-        while True:
-            data = self.request.recv(1024)
-            query += data
-            if len(data) < 1024:
-                break
+        query = self.rfile.readline().decode("utf-8").strip()
 
-        query = query.strip()
         try:
             query = query.decode("idna")
         except:


### PR DESCRIPTION
This adds Unicode support for whoisd by decoding requests using IDNA and/or UTF-8.

Responses are now sent in UTF-8.

Not sure if we should merge this on 0.28 or wait for 0.29.

Fixes #808.