### PR TITLE
Catch all exceptions to suppress error messages

### DIFF
--- a/nipap-cli/helper-nipap
+++ b/nipap-cli/helper-nipap
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     try:
         cmd = Command(nipap_cli.cmds, args)
         comp = sorted(cmd.complete())
-    except (NipapError, InvalidCommand):
+    except Exception:
         # handle errors silently
         pass
 


### PR DESCRIPTION
There are cases, such as when .nipaprc doesn't exist, that prevents
helper-nipap to work completely. Suppressing any such error message
seems to be the only reasonable option and therefore I've modified this
try/except clause to match all exceptions.

Fixes #711.