### PR TITLE
Add requirements.txt for nipap-www

### DIFF
--- a/nipap-www/requirements.txt
+++ b/nipap-www/requirements.txt
@@ -1,0 +1,3 @@
+Jinja2=2.7.3
+Pylons=1.0.2
+WebOb==1.3.1


### PR DESCRIPTION
This adds a requirements.txt for nipap-www. I haven't actually tried it
out and it is possible that we should pin more dependencies to specific
version numbers but I think this should work for now.

Looking forward to feedback from whomever might be using this.

Fixes #627