### PR TITLE
Add references to backend functions in pynipap docs

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -217,7 +217,9 @@ if on_rtd:
             else:
                 return Mock()
 
-    MOCK_MODULES = ['ldap', 'IPy', 'psycopg2.extras', 'psycopg2']
+    MOCK_MODULES = [
+        'ldap', 'IPy', 'psycopg2.extras', 'psycopg2', 'pyparsing'
+    ]
 
     for mod_name in MOCK_MODULES:
         sys.modules[mod_name] = Mock()

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -1189,6 +1189,10 @@ class Nipap:
             Add a VRF based on the values stored in the `attr` dict.
 
             Returns a dict describing the VRF which was added.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.add_vrf` for full understanding.
         """
 
         self._logger.debug("add_vrf called; attr: %s" % str(attr))
@@ -1232,6 +1236,11 @@ class Nipap:
                 A VRF specification.
 
             Remove VRF matching the `spec` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.remove_vrf` for full
+            understanding.
         """
 
         self._logger.debug("remove_vrf called; spec: %s" % str(spec))
@@ -1282,6 +1291,11 @@ class Nipap:
                 A VRF specification. If omitted, all VRFs are returned.
 
             Returns a list of dicts.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.list_vrf` for full
+            understanding.
         """
 
         if spec is None:
@@ -1354,6 +1368,11 @@ class Nipap:
                 Attibutes specifying what VRF to edit.
             * `attr` [vrf_attr]
                 Dict specifying fields to be updated and their new values.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.edit_vrf` for full
+            understanding.
         """
 
         self._logger.debug("edit_vrf called; spec: %s attr: %s" %
@@ -1474,6 +1493,11 @@ class Nipap:
             The following options are available:
                 * :attr:`max_result` - The maximum number of prefixes to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.search_vrf` for full
+            understanding.
         """
 
         if search_options is None:
@@ -1560,6 +1584,11 @@ class Nipap:
 
             See the :func:`search_vrf` function for an explanation of the
             `search_options` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.smart_search_vrf` for full
+            understanding.
         """
 
         if search_options is None:
@@ -1719,6 +1748,11 @@ class Nipap:
                 A dict containing the attributes the new pool should have.
 
             Returns a dict describing the pool which was added.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.add_pool` for full
+            understanding.
         """
 
         self._logger.debug("add_pool called; attrs: %s" % str(attr))
@@ -1759,6 +1793,11 @@ class Nipap:
                 AAA options.
             * `spec` [pool_spec]
                 Specifies what pool(s) to remove.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.remove_pool` for full
+            understanding.
         """
 
         self._logger.debug("remove_pool called; spec: %s" % str(spec))
@@ -1796,6 +1835,11 @@ class Nipap:
                 Specifies what pool(s) to list. Of omitted, all will be listed.
 
             Returns a list of dicts.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.list_pool` for full
+            understanding.
         """
 
         if spec is None:
@@ -1920,6 +1964,11 @@ class Nipap:
                 Specifies what pool to edit.
             * `attr` [pool_attr]
                 Attributes to update and their new values.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.edit_pool` for full
+            understanding.
         """
 
         self._logger.debug("edit_pool called; spec: %s attr: %s" %
@@ -2039,6 +2088,11 @@ class Nipap:
             The following options are available:
                 * :attr:`max_result` - The maximum number of pools to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many pools (default :data:`0`).
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.search_pool` for full
+            understanding.
         """
 
         if search_options is None:
@@ -2148,6 +2202,11 @@ class Nipap:
 
             See the :func:`search_pool` function for an explanation of the
             `search_options` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.smart_search_pool` for full
+            understanding.
         """
 
         if search_options is None:
@@ -2396,6 +2455,11 @@ class Nipap:
                 the :attr:`prefix` key is omitted from the `attr` argument. See the
                 documentation for the :func:`find_free_prefix` for a description of how
                 the `args` argument is to be formatted.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.add_prefix` for full
+            understanding.
         """
 
         if args is None:
@@ -2578,6 +2642,11 @@ class Nipap:
             Note that there are restrictions on when and how a prefix's type
             can be changed; reservations can be changed to assignments and vice
             versa, but only if they contain no child prefixes.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.edit_prefix` for full
+            understanding.
         """
 
         self._logger.debug("edit_prefix called; spec: %s attr: %s" %
@@ -2751,9 +2820,12 @@ class Nipap:
             how many prefixes that should be returned. If omitted, the default
             value is 1000.
 
-            The :func:`find_free_prefix` function is used internally by the
-            :func:`add_prefix` function to find available prefixes from the given
-            sources.
+            The internal backend function :func:`find_free_prefix` is used
+            internally by the :func:`add_prefix` function to find available
+            prefixes from the given sources. It's also exposed over XML-RPC,
+            please see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.find_free_prefix` for full
+            understanding.
         """
 
         # input sanity
@@ -2877,6 +2949,11 @@ class Nipap:
             This is a quite blunt tool for finding prefixes, mostly useful for
             fetching data about a single prefix. For more capable alternatives,
             see the :func:`search_prefix` or :func:`smart_search_prefix` functions.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.list_prefix` for full
+            understanding.
         """
 
         self._logger.debug("list_prefix called; spec: %s" % str(spec))
@@ -2966,6 +3043,11 @@ class Nipap:
                 AAA options.
             * `spec` [prefix_spec]
                 Specifies prefixe to remove.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.remove_prefix` for full
+            understanding.
         """
 
         self._logger.debug("remove_prefix called; spec: %s" % str(spec))
@@ -3163,6 +3245,11 @@ class Nipap:
             usable obtain search results with some context given around them,
             useful for example when displaying prefixes in a tree without the
             need to implement client side IP address logic.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.search_prefix` for full
+            understanding.
         """
 
         if search_options is None:
@@ -3450,6 +3537,11 @@ class Nipap:
 
             See the :func:`search_prefix` function for an explanation of the
             `search_options` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.smart_search_prefix` for full
+            understanding.
         """
 
         if search_options is None:
@@ -3603,7 +3695,20 @@ class Nipap:
 
 
     def list_asn(self, auth, asn=None):
-        """ List AS numbers
+        """ List AS numbers matching `spec`.
+
+            * `auth` [BaseAuth]
+                AAA options.
+            * `spec` [asn_spec]
+                An automous system number specification. If omitted, all ASNs
+                are returned.
+
+            Returns a list of dicts.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.list_asn` for full
+            understanding.
         """
 
         if asn is None:
@@ -3640,6 +3745,11 @@ class Nipap:
                 ASN attributes.
 
             Returns a dict describing the ASN which was added.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.add_asn` for full
+            understanding.
         """
 
         self._logger.debug("add_asn called; attr: %s" % str(attr))
@@ -3675,9 +3785,17 @@ class Nipap:
     def edit_asn(self, auth, asn, attr):
         """ Edit AS number
 
-            * `auth` [BaseAuth] AAA options.
-            * `asn` [integer] AS number to edit.
-            * `attr` [asn_attr] New AS attributes.
+            * `auth` [BaseAuth]
+                AAA options.
+            * `asn` [integer]
+                AS number to edit.
+            * `attr` [asn_attr]
+                New AS attributes.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.edit_asn` for full
+            understanding.
         """
 
         self._logger.debug("edit_asn called; asn: %s attr: %s" %
@@ -3721,7 +3839,19 @@ class Nipap:
 
     @requires_rw
     def remove_asn(self, auth, asn):
-        """ Remove AS number
+        """ Remove an AS number.
+
+            * `auth` [BaseAuth]
+                AAA options.
+            * `spec` [asn]
+                An ASN specification.
+
+            Remove ASNs matching the `asn` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.remove_asn` for full
+            understanding.
         """
 
         self._logger.debug("remove_asn called; asn: %s" % str(asn))
@@ -3792,6 +3922,11 @@ class Nipap:
             The following options are available:
                 * :attr:`max_result` - The maximum number of prefixes to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.search_tag` for full
+            understanding.
         """
 
         if search_options is None:
@@ -3874,6 +4009,11 @@ class Nipap:
 
             See the :func:`search_asn` function for an explanation of the
             `search_options` argument.
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.smart_search_asn` for full
+            understanding.
         """
 
         if search_options is None:
@@ -4090,6 +4230,11 @@ class Nipap:
             The following options are available:
                 * :attr:`max_result` - The maximum number of prefixes to return (default :data:`50`).
                 * :attr:`offset` - Offset the result list this many prefixes (default :data:`0`).
+
+            This is the documentation of the internal backend function. It's
+            exposed over XML-RPC, please also see the XML-RPC documentation for
+            :py:func:`nipap.xmlrpc.NipapXMLRPC.search_asn` for full
+            understanding.
         """
 
         if search_options is None:

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -4,6 +4,10 @@
 
     pynipap is a Python client library for the NIPAP IP address planning
     system. It is structured as a simple ORM.
+    To make it easy to maintain it's quite "thin", passing many arguments
+    straight through to the backend. Thus, also the pynipap-specific
+    documentation is quite thin. For in-depth information please look at the
+    main :py:mod:`NIPAP API documentation <nipap.backend>`.
 
     There are three ORM-classes:
 
@@ -12,8 +16,8 @@
     * :class:`Prefix`
 
     Each of these maps to the NIPAP objects with the same name. See the main
-    NIPAP API documentation for an overview of the different object types and
-    what they are used for.
+    :py:mod:`NIPAP API documentation <nipap.backend>` for an overview of the
+    different object types and what they are used for.
 
     There are also a few supporting classes:
 
@@ -233,8 +237,8 @@ class XMLRPCConnection:
 class Pynipap:
     """ A base class for the pynipap model classes.
 
-        All Pynipap classes which maps to data in NIPAP (:py:class:VRF,
-        :py:class:Pool, :py:class:Prefix) extends this class.
+        All Pynipap classes which maps to data in NIPAP (:py:class:`VRF`,
+        :py:class:`Pool`, :py:class:`Prefix`) extends this class.
     """
 
     _logger = None
@@ -294,7 +298,10 @@ class Tag(Pynipap):
 
     @classmethod
     def search(cls, query, search_opts=None):
-        """ Search VRFs.
+        """ Search tags.
+
+            For more information, see the backend function
+            :py:func:`nipap.backend.Nipap.search_tag`.
         """
 
         if search_opts is None:
@@ -369,6 +376,10 @@ class VRF(Pynipap):
     @classmethod
     def list(cls, vrf=None):
         """ List VRFs.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.list_vrf` in the
+            backend. Please see the documentation for the backend function for
+            information regarding input arguments and return values.
         """
 
         if vrf is None:
@@ -451,6 +462,10 @@ class VRF(Pynipap):
     @classmethod
     def search(cls, query, search_opts=None):
         """ Search VRFs.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.search_vrf` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         if search_opts is None:
@@ -479,6 +494,11 @@ class VRF(Pynipap):
     @classmethod
     def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart VRF search.
+
+            Maps to the function
+            :py:func:`nipap.backend.Nipap.smart_search_vrf` in the backend.
+            Please see the documentation for the backend function for
+            information regarding input arguments and return values.
         """
 
         if search_options is None:
@@ -508,6 +528,15 @@ class VRF(Pynipap):
 
     def save(self):
         """ Save changes made to object to NIPAP.
+
+            If the object represents a new VRF unknown to NIPAP (attribute `id`
+            is `None`) this function maps to the function
+            :py:func:`nipap.backend.Nipap.add_vrf` in the backend, used to
+            create a new VRF. Otherwise it maps to the function
+            :py:func:`nipap.backend.Nipap.edit_vrf` in the backend, used to
+            modify the VRF. Please see the documentation for the backend
+            functions for information regarding input arguments and return
+            values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -557,6 +586,10 @@ class VRF(Pynipap):
 
     def remove(self):
         """ Remove VRF.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.remove_vrf` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -607,6 +640,15 @@ class Pool(Pynipap):
 
     def save(self):
         """ Save changes made to pool to NIPAP.
+
+            If the object represents a new pool unknown to NIPAP (attribute
+            `id` is `None`) this function maps to the function
+            :py:func:`nipap.backend.Nipap.add_pool` in the backend, used to
+            create a new pool. Otherwise it maps to the function
+            :py:func:`nipap.backend.Nipap.edit_pool` in the backend, used to
+            modify the pool. Please see the documentation for the backend
+            functions for information regarding input arguments and return
+            values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -658,6 +700,10 @@ class Pool(Pynipap):
 
     def remove(self):
         """ Remove pool.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.remove_pool` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -699,6 +745,10 @@ class Pool(Pynipap):
     @classmethod
     def search(cls, query, search_opts=None):
         """ Search pools.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.search_pool` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         if search_opts is None:
@@ -728,6 +778,11 @@ class Pool(Pynipap):
     @classmethod
     def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart pool search.
+
+            Maps to the function
+            :py:func:`nipap.backend.Nipap.smart_search_pool` in the backend.
+            Please see the documentation for the backend function for
+            information regarding input arguments and return values.
         """
 
         if search_options is None:
@@ -799,6 +854,10 @@ class Pool(Pynipap):
     @classmethod
     def list(self, spec=None):
         """ List pools.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.list_pool` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         if spec is None:
@@ -889,6 +948,11 @@ class Prefix(Pynipap):
     @classmethod
     def find_free(cls, vrf, args):
         """ Finds a free prefix.
+
+            Maps to the function
+            :py:func:`nipap.backend.Nipap.find_free_prefix` in the backend.
+            Please see the documentation for the backend function for
+            information regarding input arguments and return values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -919,6 +983,11 @@ class Prefix(Pynipap):
     @classmethod
     def search(cls, query, search_opts=None):
         """ Search for prefixes.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.search_prefix`
+            in the backend. Please see the documentation for the backend
+            function for information regarding input arguments and return
+            values.
         """
 
         if search_opts is None:
@@ -948,6 +1017,11 @@ class Prefix(Pynipap):
     @classmethod
     def smart_search(cls, query_string, search_options=None, extra_query = None):
         """ Perform a smart prefix search.
+
+            Maps to the function
+            :py:func:`nipap.backend.Nipap.smart_search_prefix` in the backend.
+            Please see the documentation for the backend function for
+            information regarding input arguments and return values.
         """
 
         if search_options is None:
@@ -979,6 +1053,10 @@ class Prefix(Pynipap):
     @classmethod
     def list(cls, spec=None):
         """ List prefixes.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.list_prefix` in
+            the backend. Please see the documentation for the backend function
+            for information regarding input arguments and return values.
         """
 
         if spec is None:
@@ -1004,6 +1082,15 @@ class Prefix(Pynipap):
 
     def save(self, args=None):
         """ Save prefix to NIPAP.
+
+            If the object represents a new prefix unknown to NIPAP (attribute
+            `id` is `None`) this function maps to the function
+            :py:func:`nipap.backend.Nipap.add_prefix` in the backend, used to
+            create a new prefix. Otherwise it maps to the function
+            :py:func:`nipap.backend.Nipap.edit_prefix` in the backend, used to
+            modify the VRF. Please see the documentation for the backend
+            functions for information regarding input arguments and return
+            values.
         """
 
         if args is None:
@@ -1110,6 +1197,11 @@ class Prefix(Pynipap):
 
     def remove(self, recursive = False):
         """ Remove the prefix.
+
+            Maps to the function :py:func:`nipap.backend.Nipap.remove_prefix`
+            in the backend. Please see the documentation for the backend
+            function for information regarding input arguments and return
+            values.
         """
 
         xmlrpc = XMLRPCConnection()
@@ -1195,6 +1287,10 @@ class Prefix(Pynipap):
 
 def nipapd_version():
     """ Get version of nipapd we're connected to.
+
+        Maps to the function :py:func:`nipap.xmlrpc.NipapXMLRPC.version` in the
+        XML-RPC API. Please see the documentation for the XML-RPC function for
+        information regarding the return value.
     """
 
     xmlrpc = XMLRPCConnection()
@@ -1210,6 +1306,10 @@ def nipapd_version():
 
 def nipap_db_version():
     """ Get schema version of database we're connected to.
+
+        Maps to the function :py:func:`nipap.backend.Nipap._get_db_version` in
+        the backend. Please see the documentation for the backend function for
+        information regarding the return value.
     """
 
     xmlrpc = XMLRPCConnection()

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -9,11 +9,12 @@
     documentation is quite thin. For in-depth information please look at the
     main :py:mod:`NIPAP API documentation <nipap.backend>`.
 
-    There are three ORM-classes:
+    There are four ORM-classes:
 
     * :class:`VRF`
     * :class:`Pool`
     * :class:`Prefix`
+    * :class:`Tag`
 
     Each of these maps to the NIPAP objects with the same name. See the main
     :py:mod:`NIPAP API documentation <nipap.backend>` for an overview of the


### PR DESCRIPTION
Allright, I managed to bust up the original PR for this, #758, so here's a new one. I've added explanations regarding the mapping of functions in pynipap to backend functions to each reference. During offline discussions we debated whether the references should be to the XML-RPC functions or all the way to the backend functions, but from what I remember we agreed on referring to the backend (as that's where the information of interest actually is available), even though there is an XML-RPC layer in between.

Original message:
To avoid duplicating information the pynipap documentation is very brief as most data is passed straight to the backend anyway. This PR tries to make this more clear by adding references to the corresponding backend function to each of the pynipap class methods which involve backend operations.