### PR TITLE
Update nipap_cli.py

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -1295,7 +1295,7 @@ def remove_prefix(arg, opts, shell_opts):
                 if len(auth_src) == 0:
                     # Simple case; all prefixes were added from NIPAP
                     res = raw_input("Do you really want to recursively remove %s prefixes in %s? [y/N]: " % (len(pres['result']),
-                                vrf_format(vrf)))
+                                vrf_format(vrf).encode("utf-8")))
 
                     if res.lower() in [ 'y', 'yes' ]:
                         remove_confirmed = True

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -67,7 +67,7 @@ def setup_connection():
 
 
 def vrf_format(vrf):
-    return "VRF '%s' [RT: %s]" % (vrf.name, vrf.rt or '-')
+    return "VRF '%s' [RT: %s]" % (vrf.name.encode("utf-8"), vrf.rt or '-')
 
 
 def get_pool(arg = None, opts = None, abort = False):
@@ -1295,7 +1295,7 @@ def remove_prefix(arg, opts, shell_opts):
                 if len(auth_src) == 0:
                     # Simple case; all prefixes were added from NIPAP
                     res = raw_input("Do you really want to recursively remove %s prefixes in %s? [y/N]: " % (len(pres['result']),
-                                vrf_format(vrf).encode("utf-8")))
+                                vrf_format(vrf)))
 
                     if res.lower() in [ 'y', 'yes' ]:
                         remove_confirmed = True


### PR DESCRIPTION
Previously gave me and error and this seemed the best way to encode äöå at the time. 

Error message that I encountered
```
Recursively deleting 172.27.6.0/24 in VRF 'hemligt nät' [RT: 1337:210] will delete the following prefixes:
  172.27.6.0/24               R  None                None           None         back2back 
    172.27.6.0/29             A  None                None           None             back2back
      172.27.6.3/29           H  None                None           None           Gateway
    172.27.6.8/29             A  None                None           None             back2back
      172.27.6.11/29          H  None                None           None           Gateway
    172.27.6.16/29            A  None                None           None             back2back
      172.27.6.19/29          H  None                None           None           Gateway
    172.27.6.24/29            A  None                None           None             back2back
      172.27.6.27/29          H  None                None           None           Gateway
    172.27.6.32/29            A  None                None           None             back2back
      172.27.6.35/29          H  None                None           None           Gateway
.. and 54 other prefixes
Traceback (most recent call last):
  File "/usr/bin/nipap", line 122, in <module>
    cmd.exe(cmd.arg, cmd.exe_options, args)
  File "/usr/lib/python2.7/dist-packages/nipap_cli/nipap_cli.py", line 1220, in remove_prefix
    vrf_format(vrf)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 82: ordinal not in range(128)
```