### PR TITLE
cli: Fix XML-RPC connection for helper-nipap

### DIFF
--- a/nipap-cli/helper-nipap
+++ b/nipap-cli/helper-nipap
@@ -6,6 +6,7 @@
     commands to for example bash.
 """
 
+import ConfigParser
 import os
 import shlex
 import sys
@@ -23,6 +24,16 @@ __url__         = "http://SpriteLink.github.com/NIPAP/"
 
 if __name__ == '__main__':
 
+    # make sure nipaprc exists and has correct permissions
+    userrcfile = os.path.expanduser('~/.nipaprc')
+
+    # read configuration
+    cfg = ConfigParser.ConfigParser({'prefix_list_columns': None })
+    cfg.read(userrcfile)
+    nipap_cli.cfg = cfg
+
+    # setup our configuration
+    nipap_cli.setup_connection()
 
     comp = []
 


### PR DESCRIPTION
Tab completion for anything that required fetching data from the backend
didn't work. I don't understand how it ever did as there's no code to
set up the XML-RPC connection.

This adds some code, more or less copied from the CLI. We don't check
the permissions like we do in the CLI, but I figure the user will get a
warning about that soon enough anyway.