### PR TITLE
nipapd: enable search on prefix-length

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -400,6 +400,10 @@ _prefix_spec = {
             'column': 'inp.prefix',
             'ro': False,
         },
+        'prefix_length': {
+            'column': 'masklen(inp.prefix)',
+            'ro': True,
+        },
         'status': {
             'column': 'inp.status',
             'ro': False,


### PR DESCRIPTION
This enables search based on prefix-length as a match. It's using the
masklen() function in Postgres to do this and there is currently no
functional index on that so it might be slow.

Fixes #847.