### PR TITLE
Some IPv6 prefixes can't be looked up via the whois server

### DIFF
--- a/whoisd/nipap-whoisd
+++ b/whoisd/nipap-whoisd
@@ -99,6 +99,13 @@ class WhoisServer(SocketServer.StreamRequestHandler):
                 for p in res['result']:
                     response += format_prefix(p)
                     response += '\n'
+            # 1234:123:: - IPv6
+            res = Prefix.smart_search(query, { })
+            if len(res['result']) > 0:
+                total_hits += len(res['result'])
+                for p in res['result']:
+                    response += format_prefix(p)
+                    response += '\n'
         else:
             # respond with VRFs
             res = VRF.smart_search(query, { })


### PR DESCRIPTION
The regex that matches VRF RT's also captures IPv6 addresses without letters in the first two sections of the address.

This pull request should fix that.