### PR TITLE
Drop postgres dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,12 @@ install:
     # configure .nipaprc
     - sed -e 's/username = guest/username = unittest/' -e 's/password = guest/password = gottatest/' nipap-cli/nipaprc > ~/.nipaprc
     - chmod 0600 ~/.nipaprc
+    # install postgresql + ip4r + contrib
+    - apt-get install -qq -y postgresql-9.1-ip4r postgresql-9.1-contrib
 
     # -- virtualenv build ------------------------------------------------------
     # install nipap dependencies
     - if [ "$INSTALL" == "venv" ]; then pip install -r nipap/requirements.txt; fi
-    # install postgresql module (can't get from pip).
-    - if [ "$INSTALL" == "venv" ]; then sudo apt-get install -qq -y postgresql-9.1-ip4r; fi
     # SQL
     - if [ "$INSTALL" == "venv" ]; then sudo su -c "cd nipap/sql; make install" postgres; fi
     # move configuration file into place

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
     - sed -e 's/username = guest/username = unittest/' -e 's/password = guest/password = gottatest/' nipap-cli/nipaprc > ~/.nipaprc
     - chmod 0600 ~/.nipaprc
     # install postgresql + ip4r + contrib
-    - apt-get install -qq -y postgresql-9.1-ip4r postgresql-9.1-contrib
+    - sudo apt-get install -qq -y postgresql-9.1-ip4r postgresql-9.1-contrib
 
     # -- virtualenv build ------------------------------------------------------
     # install nipap dependencies

--- a/docs/install-debian.rst
+++ b/docs/install-debian.rst
@@ -12,6 +12,20 @@ instructions on non-Debian like Unix systems.
 
 Debian installation
 -------------------
+Start by installing PostgreSQL, the contrib package and the ip4r extension.
+Depending on which Debian or Ubuntu release you are running, different versions
+are available. Anything after PostgreSQL 9.0 will do. Make sure you install
+ip4r and the contrib package for your version of Postgres or if this is a fresh
+install you can specify the version you want of ip4r and it will pull in the
+same version of postgresql::
+
+    root@debian:~# apt-cache search ip4r
+    postgresql-9.1-ip4r - IPv4 and IPv6 types for PostgreSQL 9.1
+    postgresql-8.4-ip4r - IPv4 and IPv4 range index types for PostgreSQL 8.4
+    root@debian:~# apt-cache search postgres contrib
+    postgresql-contrib-9.1 - additional facilities for PostgreSQL
+    root@debian:~# apt-get install postgresql-9.1-ip4r postgresql-contrib-9.1
+
 Add the NIPAP repo to your package sources, add our public key for proper
 authentication of our packages and update your lists::
 

--- a/nipap/debian/control
+++ b/nipap/debian/control
@@ -17,7 +17,7 @@ Description: Neat IP Address Planner
 
 Package: nipapd
 Architecture: all
-Depends: debconf, nipap-common, python (>= 2.7), ${misc:Depends}, python-psycopg2, postgresql (>=9.1) | postgresql-9.1 | postgresql-9.2 | postgresql-9.3 | postgresql-9.4, postgresql-9.1-ip4r (>= 2.0) | postgresql-9.3-ip4r (>= 2.0) | postgresql-9.4-ip4r (>= 2.0), postgresql-contrib | postgresql-contrib-9.3, python-flask, python-flask-xml-rpc, python-flask-compress, python-tornado, python-parsedatetime, python-tz, python-dateutil, python-psutil, python-pyparsing
+Depends: debconf, nipap-common, python (>= 2.7), ${misc:Depends}, python-psycopg2, python-flask, python-flask-xml-rpc, python-flask-compress, python-tornado, python-parsedatetime, python-tz, python-dateutil, python-psutil, python-pyparsing
 Description: Neat IP Address Planner XML-RPC daemon
  The Neat IP Address Planner, NIPAP, is a system built for efficiently managing
  large amounts of IP addresses. This is the XML-RPC daemon.


### PR DESCRIPTION
This removes the dependency on postgres from the nipapd package, allowing postgres to be installed on another machine. In addition nipapd can now be installed on the latest versions of Ubuntu as they have a newer postgresql version than we specified in our control file.