### PR TITLE
Docs - Initialize SQLite auth database

### DIFF
--- a/docs/install-unix.rst
+++ b/docs/install-unix.rst
@@ -67,6 +67,17 @@ Install the nipapd daemon and CLI client::
     cd ../nipap-cli
     python setup.py install
 
+Initialize SQLite auth database
+-------------------------------
+
+    # ls -l /etc/nipap/local_auth.db
+    -rw-r--r-- 1 root root 0 Jun 14 14:26 /etc/nipap/local_auth.db
+    
+    # nipap-passwd --create-database
+    
+    ls -l /etc/nipap/local_auth.db
+    -rw-r--r-- 1 root root 3.1k Jun 14 16:52 /etc/nipap/local_auth.db
+
 
 Running nipapd
 --------------


### PR DESCRIPTION
Just to have this in the docs, worked on CentOS 7 
https://github.com/SpriteLink/NIPAP/issues/802