### PR TITLE
fix: NameError: name 'options' is not defined

### DIFF
--- a/nipap/nipap-passwd
+++ b/nipap/nipap-passwd
@@ -80,7 +80,7 @@ if __name__ == '__main__':
             print "The user %s does not exist" % args.user
             sys.exit(2)
         af = nipap.authlib.AuthFactory()
-        auth = af.get_auth(options.username, options.password, "nipap", {})
+        auth = af.get_auth(args.user, args.password, "nipap", {})
         if not auth.authenticate():
             print "The password seems to be wrong"
             sys.exit(2)


### PR DESCRIPTION
```
[root@nipap nipap-www]# nipap-passwd test-user -u cli -p cli
Traceback (most recent call last):
  File "/sbin/nipap-passwd", line 71, in <module>
    auth = af.get_auth(options.username, options.password, "nipap", {})
NameError: name 'options' is not defined
```