### PR TITLE
fix DistributionNotFound: nipap-www

### DIFF
--- a/nipap-www/nipap-www.wsgi
+++ b/nipap-www/nipap-www.wsgi
@@ -3,6 +3,7 @@
 #
 
 import os, sys
+sys.path.append('/path/to/nipap/NIPAP/nipap-www/')
 os.environ['PYTHON_EGG_CACHE'] = '/var/cache/nipap-www/eggs'
 
 from paste.deploy import loadapp


### PR DESCRIPTION
Fix the error 

```
[Wed Jun 15 21:41:39.062272 2016] [:error] [pid 29250] [client 192.168.0.1:55019] mod_wsgi (pid=29250): Target WSGI script '/movile/nipap/NIPAP/nipap-www/nipap-www.wsgi' cannot be loaded as Python module.
[Wed Jun 15 21:41:39.062307 2016] [:error] [pid 29250] [client 192.168.0.1:55019] mod_wsgi (pid=29250): Exception occurred processing WSGI script '/movile/nipap/NIPAP/nipap-www/nipap-www.wsgi'.
[Wed Jun 15 21:41:39.062325 2016] [:error] [pid 29250] [client 192.168.0.1:55019] Traceback (most recent call last):
[Wed Jun 15 21:41:39.062339 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/movile/nipap/NIPAP/nipap-www/nipap-www.wsgi", line 11, in <module>
[Wed Jun 15 21:41:39.062392 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     application = loadapp('config:/movile/nipap/NIPAP/nipap-www/nipap-www.ini')
[Wed Jun 15 21:41:39.062403 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
[Wed Jun 15 21:41:39.062599 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     return loadobj(APP, uri, name=name, **kw)
[Wed Jun 15 21:41:39.062621 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 271, in loadobj
[Wed Jun 15 21:41:39.062638 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     global_conf=global_conf)
[Wed Jun 15 21:41:39.062646 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
[Wed Jun 15 21:41:39.062656 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     global_conf=global_conf)
[Wed Jun 15 21:41:39.062681 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 320, in _loadconfig
[Wed Jun 15 21:41:39.062693 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     return loader.get_context(object_type, name, global_conf)
[Wed Jun 15 21:41:39.062700 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 454, in get_context
[Wed Jun 15 21:41:39.062708 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     section)
[Wed Jun 15 21:41:39.062713 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 476, in _context_from_use
[Wed Jun 15 21:41:39.062722 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     object_type, name=use, global_conf=global_conf)
[Wed Jun 15 21:41:39.062732 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 406, in get_context
[Wed Jun 15 21:41:39.062740 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     global_conf=global_conf)
[Wed Jun 15 21:41:39.062745 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
[Wed Jun 15 21:41:39.062756 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     global_conf=global_conf)
[Wed Jun 15 21:41:39.062762 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 328, in _loadegg
[Wed Jun 15 21:41:39.062771 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     return loader.get_context(object_type, name, global_conf)
[Wed Jun 15 21:41:39.062775 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 620, in get_context
[Wed Jun 15 21:41:39.062787 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     object_type, name=name)
[Wed Jun 15 21:41:39.062793 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 640, in find_egg_entry_point
[Wed Jun 15 21:41:39.062802 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     pkg_resources.require(self.spec)
[Wed Jun 15 21:41:39.062807 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 728, in require
[Wed Jun 15 21:41:39.063331 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     needed = self.resolve(parse_requirements(requirements))
[Wed Jun 15 21:41:39.063342 2016] [:error] [pid 29250] [client 192.168.0.1:55019]   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 626, in resolve
[Wed Jun 15 21:41:39.063356 2016] [:error] [pid 29250] [client 192.168.0.1:55019]     raise DistributionNotFound(req)
[Wed Jun 15 21:41:39.063375 2016] [:error] [pid 29250] [client 192.168.0.1:55019] DistributionNotFound: nipap-www
```


