### PR TITLE
Support unlimited max_result for search_prefix

### DIFF
--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -1768,7 +1768,7 @@ function collapseClick(id) {
 		search_q.include_children = false;
 		search_q.children_depth = 1;
 		search_q.parents_depth = 0;
-		search_q.max_result = 1000;
+		search_q.max_result = false;
 		search_q.offset = 0;
 		delete search_q.indent;
 


### PR DESCRIPTION
For certain queries, like when expanding a prefix by clicking the '+' in
the web UI we really shouldn't have a limit. Unlimited is signified by
setting max_result to False or None.

Downside might be DoS attack on the backend or some incorrect logic
somewhere blowing it up with heavy queries inadvertently.

Fixes #466.