### PR TITLE
whoisd: enable foreground mode

### DIFF
--- a/whoisd/nipap-whoisd
+++ b/whoisd/nipap-whoisd
@@ -137,6 +137,7 @@ if __name__ == '__main__':
     import optparse
     parser = optparse.OptionParser()
     parser.add_option("--config", dest="config_file", type="string", default="/etc/nipap/nipap.conf", help="read configuration from file CONFIG_FILE")
+    parser.add_option("--foreground", action="store_true", help="run in foreground")
     parser.add_option("--listen", metavar="ADDRESS", help="listen on IPv4/6 ADDRESS")
     parser.add_option("--port", type=int, default=43, help="port to listen to")
     parser.add_option("--pid-file", type="string", help="write a PID file to PID_FILE")
@@ -183,6 +184,7 @@ if __name__ == '__main__':
             print >> sys.stderr, "The configuration file contains errors:", exc
             sys.exit(1)
 
+    SocketServer.TCPServer.allow_reuse_address = True
     try:
         server = ForkingTCPServer((cfg.get('whoisd', 'listen'),
             int(cfg.get('whoisd', 'port'))), WhoisServer)
@@ -208,7 +210,8 @@ if __name__ == '__main__':
             sys.exit(1)
 
     # daemonize
-    nipap_whoisd.createDaemon()
+    if not options.foreground:
+        nipap_whoisd.createDaemon()
 
     # pid file handling
     if cfg.get('whoisd', 'pid_file') and not options.no_pid_file:
@@ -238,4 +241,7 @@ if __name__ == '__main__':
     ao = pynipap.AuthOptions({'authoritative_source': 'nipap'})
 
     # and serve!
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    except:
+        server.shutdown()


### PR DESCRIPTION
Allow running in the foreground.

Shut down cleanly.

Also avoid the error message around address already in use through
address reuse.

Fixes #920.