### PR TITLE
Fix broken parsing of VRF RT

### DIFF
--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -432,39 +432,17 @@ class PrefixSmartParser(SmartParser):
         elif part.getName() == 'ipv4_address':
             dictsql = {}
         elif part.getName() == 'vrf_rt':
-            self._logger.debug("Query part '" + part.vrf_rt[0] + "' interpreted as VRF RT")
-            # TODO: enable this, our fancy new interpretation
+            self._logger.debug("Query part '" + part.vrf_rt + "' interpreted as VRF RT")
             dictsql = {
                     'interpretation': {
                         'attribute': 'VRF RT',
                         'interpretation': 'vrf_rt',
                         'operator': 'equals',
-                        'string': part.vrf_rt[0]
+                        'string': part.vrf_rt
                         },
                     'operator': 'equals',
                     'val1': 'vrf_rt',
-                    'val2': part.vrf_rt[0]
-                    }
-            # using old interpretation for the time being to make sure we align
-            # with old smart search interpreter
-            dictsql = {
-                    'interpretation': {
-                        'attribute': 'name or description',
-                        'interpretation': 'text',
-                        'operator': 'regex',
-                        'string': part.vrf_rt[0]
-                        },
-                    'operator': 'or',
-                    'val1': {
-                        'operator': 'regex_match',
-                        'val1': 'name',
-                        'val2': part.vrf_rt[0]
-                        },
-                    'val2': {
-                        'operator': 'regex_match',
-                        'val1': 'description',
-                        'val2': part.vrf_rt[0]
-                        }
+                    'val2': part.vrf_rt
                     }
 
         else:

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -2010,6 +2010,26 @@ class TestSmartParser(unittest.TestCase):
 
 
 
+    def test_prefix6(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('123:456')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'VRF RT',
+                    'string': '123:456',
+                    'interpretation': 'vrf_rt',
+                    'operator': 'equals',
+                },
+                'operator': 'equals',
+                'val1': 'vrf_rt',
+                'val2': u'123:456'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
     def test_vrf1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()


### PR DESCRIPTION
The backend smart parsing function currently builds broken queries for stuff that looks like a VRF RT, like '123:456'. This fixes that and adds a test case to make sure we catch this in the future.