### PR TITLE
backend: fix smart parsing of IPv6 prefixes

### DIFF
--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -2030,6 +2030,130 @@ class TestSmartParser(unittest.TestCase):
 
 
 
+    def test_prefix7(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('2001:1000::/32')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv6 prefix',
+                    'operator': 'contained_within_equals',
+                    'string': '2001:1000::/32'
+                },
+                'operator': 'contained_within_equals',
+                'val1': 'prefix',
+                'val2': '2001:1000::/32'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_prefix8(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('2001:1000:1234::/32')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv6 prefix',
+                    'operator': 'contained_within_equals',
+                    'string': '2001:1000:1234::/32',
+                    'strict_prefix': '2001:1000::/32'
+                },
+                'operator': 'contained_within_equals',
+                'val1': 'prefix',
+                'val2': '2001:1000::/32'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_prefix9(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('2001:1000::')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv6 address',
+                    'operator': 'contains_equals',
+                    'string': '2001:1000::'
+                },
+                'operator': 'contains_equals',
+                'val1': 'prefix',
+                'val2': '2001:1000::'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_prefix10(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('1.3.3.0')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv4 address',
+                    'operator': 'contains_equals',
+                    'string': '1.3.3.0'
+                },
+                'operator': 'contains_equals',
+                'val1': 'prefix',
+                'val2': '1.3.3.0'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_prefix11(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('1.3.3.0/16')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv4 prefix',
+                    'operator': 'contained_within_equals',
+                    'string': '1.3.3.0/16',
+                    'strict_prefix': '1.3.0.0/16'
+                },
+                'operator': 'contained_within_equals',
+                'val1': 'prefix',
+                'val2': '1.3.0.0/16'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
+    def test_prefix12(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+        query = n._parse_prefix_query('1.3.3/16')
+        exp_query = {
+                'interpretation': {
+                    'attribute': 'prefix',
+                    'interpretation': 'IPv4 prefix',
+                    'operator': 'contained_within_equals',
+                    'string': '1.3.3/16',
+                    'strict_prefix': '1.3.0.0/16',
+                    'expanded': '1.3.3.0/16'
+                },
+                'operator': 'contained_within_equals',
+                'val1': 'prefix',
+                'val2': '1.3.0.0/16'
+                }
+
+        self.assertEqual(query, exp_query)
+
+
+
     def test_vrf1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()


### PR DESCRIPTION
The new smart parser that I wrote didn't correctly parse IPv6 addresses,
instead mistaking them for VRF RTs, which are also colon separated
numbers. We didn't have a test case for this and I believe I didn't
catch this earlier as I probably use the Tele2 IPv6 prefix 2a00:db8::/25
that contains hexadecimal characters, thus differing from a VRF RT.

I have now added the explicit classes ipv6_address and ipv6_prefix which
also lead to their own expansion from AST to dictsql.

There are now also test cases to cover shortened IPv4 prefixes (like
10.0/8) and IPv4 prefixes with bits set in host part so we check that
the strict prefix mangling works.

Fixes #954.