### PR TITLE
Use argparse instead of optparse

### DIFF
--- a/nipap/xml-test.py
+++ b/nipap/xml-test.py
@@ -3,22 +3,22 @@
 
 import xmlrpclib
 
-import optparse
+import argparse
 import time
 import sys
 
-parser = optparse.OptionParser()
-parser.add_option('-p', '--port', dest='port', type='int', default='1337', help="TCP port")
-parser.add_option('-U', '--user')
-parser.add_option('-P', '--password')
+parser = argparse.ArgumentParser()
+parser.add_argument('-p', '--port', dest='port', type='int', default='1337', help="TCP port")
+parser.add_argument('-U', '--user')
+parser.add_argument('-P', '--password')
 
-(options, args) = parser.parse_args()
+args = parser.parse_args()
 
 cred = ''
-if options.user and options.password:
-	cred = options.user + ':' + options.password + '@'
+if args.user and args.password:
+	cred = args.user + ':' + args.password + '@'
 
-server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': options.port, 'cred': cred }
+server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': args.port, 'cred': cred }
 server = xmlrpclib.Server(server_url, allow_none=1);
 
 ad = { 'authoritative_source': 'nipap' }

--- a/nipap/xmlbench.py
+++ b/nipap/xmlbench.py
@@ -118,27 +118,27 @@ class Benchmark():
 
 
 if __name__ == '__main__':
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('-p', '--port', dest='port', type='int', default='1337', help="TCP port")
-    parser.add_option('-U', '--user')
-    parser.add_option('-P', '--password')
-    parser.add_option('--concurrent', type='int', default=10, help="Concurrent requests")
-    parser.add_option('--total', type='int', default=100, help="Total number of requests")
-    parser.add_option('--method', help="XML-RPC method to benchmark")
-    parser.add_option('--args', help="Args to XML-RPC method")
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', dest='port', type='int', default='1337', help="TCP port")
+    parser.add_argument('-U', '--user')
+    parser.add_argument('-P', '--password')
+    parser.add_argument('--concurrent', type='int', default=10, help="Concurrent requests")
+    parser.add_argument('--total', type='int', default=100, help="Total number of requests")
+    parser.add_argument('--method', help="XML-RPC method to benchmark")
+    parser.add_argument('--args', help="Args to XML-RPC method")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
     cred = ''
-    if options.user and options.password:
-        cred = options.user + ':' + options.password + '@'
-    server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': options.port, 'cred': cred }
+    if args.user and args.password:
+        cred = args.user + ':' + args.password + '@'
+    server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': args.port, 'cred': cred }
 
     ad = { 'authoritative_source': 'nipap' }
     args = [{ 'auth': ad, 'message': 'test', 'sleep': 0.1 }]
     args = [{ 'auth': ad, 'query_string': 'foo' }]
-    b = Benchmark(concurrent = options.concurrent, total = options.total, url =
-            server_url, method = options.method, params = args)
+    b = Benchmark(concurrent = args.concurrent, total = args.total, url =
+            server_url, method = args.method, params = args)
     b.setupReqs()
     reactor.run()

--- a/tests/performance/speedtest.py
+++ b/tests/performance/speedtest.py
@@ -183,28 +183,28 @@ class bonk:
 
 
 if __name__ == '__main__':
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('--add-prefix', metavar = 'PREFIX', help='Add PREFIX')
-    parser.add_option('--fill-prefix', metavar = 'PREFIX', help='fill PREFIX with hosts')
-    parser.add_option('--find-free-prefix', metavar = 'PREFIX', help='try to find the next free /32 in PREFIX')
-    parser.add_option('--remove-prefix', metavar = 'PREFIX', help='delete PREFIX')
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--add-prefix', metavar = 'PREFIX', help='Add PREFIX')
+    parser.add_argument('--fill-prefix', metavar = 'PREFIX', help='fill PREFIX with hosts')
+    parser.add_argument('--find-free-prefix', metavar = 'PREFIX', help='try to find the next free /32 in PREFIX')
+    parser.add_argument('--remove-prefix', metavar = 'PREFIX', help='delete PREFIX')
     b = bonk()
 
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
-    if options.fill_prefix is not None:
-        if not b.n._get_afi(options.fill_prefix):
+    if args.fill_prefix is not None:
+        if not b.n._get_afi(args.fill_prefix):
             print >> sys.stderr, "Please enter a valid prefix"
             sys.exit(1)
-        b.fill_prefix(options.fill_prefix)
+        b.fill_prefix(args.fill_prefix)
 
 
-    if options.find_free_prefix is not None:
-        b.find_free_prefix(options.find_free_prefix)
+    if args.find_free_prefix is not None:
+        b.find_free_prefix(args.find_free_prefix)
 
-    if options.add_prefix is not None:
-        b.add_prefix(options.add_prefix)
+    if args.add_prefix is not None:
+        b.add_prefix(args.add_prefix)
 
-    if options.remove_prefix is not None:
-        b.remove_prefix(options.remove_prefix)
+    if args.remove_prefix is not None:
+        b.remove_prefix(args.remove_prefix)

--- a/utilities/boilerplate.py
+++ b/utilities/boilerplate.py
@@ -24,21 +24,21 @@ if __name__ == '__main__':
     cfg = ConfigParser.ConfigParser()
     cfg.read(os.path.expanduser('~/.nipaprc'))
 
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('--username', help="NIPAP backend username")
-    parser.add_option('--password', help="NIPAP backend password")
-    parser.add_option('--host', help="NIPAP backend host")
-    parser.add_option('--port', help="NIPAP backend port")
-    (options, args) = parser.parse_args()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', help="NIPAP backend username")
+    parser.add_argument('--password', help="NIPAP backend password")
+    parser.add_argument('--host', help="NIPAP backend host")
+    parser.add_argument('--port', help="NIPAP backend port")
+    args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (options.username or cfg.get('global', 'username'),
-            options.password or cfg.get('global', 'password'))
+    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+            args.password or cfg.get('global', 'password'))
 
     xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
             'auth_uri'  : auth_uri,
-            'host'      : options.host or cfg.get('global', 'hostname'),
-            'port'      : options.port or cfg.get('global', 'port')
+            'host'      : args.host or cfg.get('global', 'hostname'),
+            'port'      : args.port or cfg.get('global', 'port')
             }
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri

--- a/utilities/export-csv.py
+++ b/utilities/export-csv.py
@@ -41,34 +41,34 @@ class Export:
 
 
 if __name__ == '__main__':
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('--username', default='', help="Username")
-    parser.add_option('--password', default='', help="Password")
-    parser.add_option('--host', help="NIPAP backend host")
-    parser.add_option('--port', default=1337, help="NIPAP backend port")
-    parser.add_option('--query', default = '', help="A prefix query string")
-    parser.add_option('--file', help="Output file")
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', default='', help="Username")
+    parser.add_argument('--password', default='', help="Password")
+    parser.add_argument('--host', help="NIPAP backend host")
+    parser.add_argument('--port', default=1337, help="NIPAP backend port")
+    parser.add_argument('--query', default = '', help="A prefix query string")
+    parser.add_argument('--file', help="Output file")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if options.host is None:
+    if args.host is None:
         print >> sys.stderr, "Please specify the NIPAP backend host to work with"
         sys.exit(1)
 
-    if options.file is None:
+    if args.file is None:
         print >> sys.stderr, "Please specify an output file"
         sys.exit(1)
 
     auth_uri = ''
-    if options.username:
-        auth_uri = "%s:%s@" % (options.username, options.password)
+    if args.username:
+        auth_uri = "%s:%s@" % (args.username, args.password)
 
     xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
             'auth_uri'  : auth_uri,
-            'host'      : options.host,
-            'port'      : options.port
+            'host'      : args.host,
+            'port'      : args.port
             }
 
     wr = Export(xmlrpc_uri)
-    wr.write(options.file, options.query)
+    wr.write(args.file, args.query)

--- a/utilities/export-template.py
+++ b/utilities/export-template.py
@@ -5,7 +5,7 @@
     template that can be used to produce a configuration file for another
     program, such as ISC DHCP.
 
-    It will read .nipaprc per default or rely on command line options for
+    It will read .nipaprc per default or rely on command line arguments for
     connection settings to the backend.
 """
 
@@ -68,38 +68,38 @@ if __name__ == '__main__':
     cfg = ConfigParser.ConfigParser()
     cfg.read(os.path.expanduser('~/.nipaprc'))
 
-    import optparse
-    parser = optparse.OptionParser()
-    # standard options to specify nipapd connection
-    parser.add_option('--username', help="NIPAP backend username")
-    parser.add_option('--password', help="NIPAP backend password")
-    parser.add_option('--host', help="NIPAP backend host")
-    parser.add_option('--port', help="NIPAP backend port")
+    import argparse
+    parser = argparse.ArgumentParser()
+    # standard arguments to specify nipapd connection
+    parser.add_argument('--username', help="NIPAP backend username")
+    parser.add_argument('--password', help="NIPAP backend password")
+    parser.add_argument('--host', help="NIPAP backend host")
+    parser.add_argument('--port', help="NIPAP backend port")
 
-    parser.add_option('--template', help="template file")
-    parser.add_option('--output-file', help="output file")
-    parser.add_option('--query', default='', help="query for filtering prefixes")
-    (options, args) = parser.parse_args()
+    parser.add_argument('--template', help="template file")
+    parser.add_argument('--output-file', help="output file")
+    parser.add_argument('--query', default='', help="query for filtering prefixes")
+    args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (options.username or cfg.get('global', 'username'),
-            options.password or cfg.get('global', 'password'))
+    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+            args.password or cfg.get('global', 'password'))
 
     xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
             'auth_uri'  : auth_uri,
-            'host'      : options.host or cfg.get('global', 'hostname'),
-            'port'      : options.port or cfg.get('global', 'port')
+            'host'      : args.host or cfg.get('global', 'hostname'),
+            'port'      : args.port or cfg.get('global', 'port')
             }
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 
-    if not options.template:
+    if not args.template:
         print("Please specify a template file", file=sys.stderr)
         sys.exit(1)
 
-    if not options.output_file:
+    if not args.output_file:
         print("Please specify an output file", file=sys.stderr)
         sys.exit(1)
 
-    ce = ConfigExport(options.template, options.output_file)
-    ce.get_prefixes(options.query)
+    ce = ConfigExport(args.template, args.output_file)
+    ce.get_prefixes(args.query)
     ce.write_conf()

--- a/utilities/remove-all.py
+++ b/utilities/remove-all.py
@@ -27,35 +27,35 @@ if __name__ == '__main__':
     cfg = ConfigParser.ConfigParser()
     cfg.read(os.path.expanduser('~/.nipaprc'))
 
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('--username', help="NIPAP backend username")
-    parser.add_option('--password', help="NIPAP backend password")
-    parser.add_option('--host', help="NIPAP backend host")
-    parser.add_option('--port', help="NIPAP backend port")
-    parser.add_option('--clear-pools', action='store_true',
-                      help="Remove all pools in NIPAP")
-    parser.add_option('--clear-prefixes', action='store_true',
-                      help="Remove all prefixes in NIPAP")
-    parser.add_option('--clear-vrfs', action='store_true',
-                      help="Remove all VRFs in NIPAP")
-    parser.add_option("-f", "--force", action="store_true", default=False,
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', help="NIPAP backend username")
+    parser.add_argument('--password', help="NIPAP backend password")
+    parser.add_argument('--host', help="NIPAP backend host")
+    parser.add_argument('--port', help="NIPAP backend port")
+    parser.add_argument('--clear-pools', action='store_true',
+                        help="Remove all pools in NIPAP")
+    parser.add_argument('--clear-prefixes', action='store_true',
+                        help="Remove all prefixes in NIPAP")
+    parser.add_argument('--clear-vrfs', action='store_true',
+                        help="Remove all VRFs in NIPAP")
+    parser.add_argument("-f", "--force", action="store_true", default=False,
                       help="disable interactive prompting of actions")
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (options.username or cfg.get('global', 'username'),
-            options.password or cfg.get('global', 'password'))
+    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+            args.password or cfg.get('global', 'password'))
 
     xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
             'auth_uri'  : auth_uri,
-            'host'      : options.host or cfg.get('global', 'hostname'),
-            'port'      : options.port or cfg.get('global', 'port')
+            'host'      : args.host or cfg.get('global', 'hostname'),
+            'port'      : args.port or cfg.get('global', 'port')
             }
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 
-    if options.clear_vrfs:
-        remove_confirmed = options.force
+    if args.clear_vrfs:
+        remove_confirmed = args.force
         if not remove_confirmed:
             res = raw_input("Are you sure you want to remove all VRFs? Note how all" +
                             " prefixes in these VRFs WILL BE DELETED. The default VRF" +
@@ -75,8 +75,8 @@ if __name__ == '__main__':
                 sys.stdout.flush()
             print " done!"
 
-    if options.clear_pools:
-        remove_confirmed = options.force
+    if args.clear_pools:
+        remove_confirmed = args.force
         if not remove_confirmed:
             res = raw_input("Are you sure you want to remove all pools? [y/N]")
             if len(res) > 0 and res.lower()[0] == 'y':
@@ -92,8 +92,8 @@ if __name__ == '__main__':
                 sys.stdout.flush()
             print " done!"
 
-    if options.clear_prefixes:
-        remove_confirmed = options.force
+    if args.clear_prefixes:
+        remove_confirmed = args.force
         if not remove_confirmed:
             res = raw_input("Are you sure you want to remove all prefixes? [y/N]")
             if len(res) > 0 and res.lower()[0] == 'y':

--- a/utilities/text-import.py
+++ b/utilities/text-import.py
@@ -337,18 +337,18 @@ class TextImporter(Importer):
 
 
 if __name__ == '__main__':
-    import optparse
-    parser = optparse.OptionParser()
-    parser.add_option('--schema', help = 'Name of schema to import into')
-    parser.add_option('--url', default='http://127.0.0.1:1337/', help = 'the NIPAP XML-RPC server url')
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--schema', help = 'Name of schema to import into')
+    parser.add_argument('--url', default='http://127.0.0.1:1337/', help = 'the NIPAP XML-RPC server url')
 
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
-    if options.schema is None:
+    if args.schema is None:
         print >> sys.stderr, "You must specify a schema"
         sys.exit(1)
 
-    ti = TextImporter(options.url, options.schema)
+    ti = TextImporter(args.url, args.schema)
     for filename in args:
         ti.parse_file(filename)
 


### PR DESCRIPTION
argparse is the modern alternative and the recommended lib for parsing command line arguments. I think optparse isn't even in py3.

All these changes are written blind - I haven't tested anything but I actually think that should be fine =) Easy to fix if anything should pop up.

Part of #747.