### PR TITLE
backend: switch nipap.conf.dist to Jinja2 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,14 +61,14 @@ install:
     # SQL
     - if [ "$INSTALL" == "venv" ]; then sudo su -c "cd nipap/sql; make install" postgres; fi
     # move configuration file into place
-    - if [ "$INSTALL" == "venv" ]; then sudo mkdir /etc/nipap; sudo cp nipap/nipap.conf.dist /etc/nipap/nipap.conf; fi
+    - if [ "$INSTALL" == "venv" ]; then sudo mkdir /etc/nipap; sudo cp nipap/nipap.conf.dist /etc/nipap/nipap.conf; sudo sed -e "s/{{LISTEN_ADDRESS}}/127.0.0.1/" -e "s/{{LISTEN_PORT}}/1337/" -e "s/{{DB_USERNAME}}/nipap/" -e "s/{{DB_NAME}}/nipap/" -e "s/{{DB_PASSWORD}}/papin/" -e "s/{{DB_SSLMODE}}/require/" -e "s/{{DB_PORT}}/5432/" -e "s/{{DB_HOST}}/localhost/" -e "s/{{SYSLOG}}/true/" -i /etc/nipap/nipap.conf; fi
     # create local user for unittest
     - if [ "$INSTALL" == "venv" ]; then sudo nipap/nipap-passwd create-database; sudo nipap/nipap-passwd add -u unittest -p gottatest -n unittest; fi
     - if [ "$INSTALL" == "venv" ]; then sudo nipap/nipap-passwd add -u readonly -p gottatest --readonly -n "Read-only user for running unit tests"; fi
     # install pynipap
     - if [ "$INSTALL" == "venv" ]; then cd pynipap; python setup.py install; cd ..; fi
     # start nipap backend
-    - if [ "$INSTALL" == "venv" ]; then nipap/nipapd --no-pid-file -c nipap/nipap.conf.dist; fi
+    - if [ "$INSTALL" == "venv" ]; then nipap/nipapd --no-pid-file -c /etc/nipap/nipap.conf; fi
 
     # -- APT build --------------------------------------------------------------
     # add NIPAP official Debian repo and keys, we use it to get ip4r

--- a/nipap/debian/nipapd.postinst
+++ b/nipap/debian/nipapd.postinst
@@ -46,13 +46,13 @@ case "$1" in
 	configure)
 		if [ ! -e "/etc/nipap/nipap.conf" ]; then
 			# update nipap.conf with database credentials
-			cat /etc/nipap/nipap.conf.dist | sed -e "s/#user *= *[^ ]\+/user = nipap/" -e "s/db_user *= *[^ ]\+/db_user = $DB_USER /" -e "s/db_name *= *[^ ]\+/db_name = $DB_NAME /" -e "s/db_pass *= *[^ ]\+/db_pass = $DB_PASS /" > /etc/nipap/nipap.conf
+			cat /etc/nipap/nipap.conf.dist | sed -e "s/#user *= *[^ ]\+/user = nipap/" -e "s/{{LISTEN_ADDRESS}}/127.0.0.1/" -e "s/{{LISTEN_PORT}}/1337/" -e "s/{{DB_USERNAME}}/$DB_USER/" -e "s/{{DB_NAME}}/$DB_NAME/" -e "s/{{DB_PASSWORD}}/$DB_PASS/" -e "s/{{DB_SSLMODE}}/require/" -e "s/{{DB_PORT}}/5432/" -e "s/{{SYSLOG}}/true/" > /etc/nipap/nipap.conf
 		fi
 		# fill in db_host
 		if [ $DB_HOST = "localhost" ]; then
-			sed -e 's/db_host *= *[^ ]\+/db_host = ""/' -i /etc/nipap/nipap.conf
+			sed -e 's/{{DB_HOST}}/""/' -i /etc/nipap/nipap.conf
 		else
-			sed -e "s/db_host *= *[^ ]\+/db_host = $DB_HOST/" -i /etc/nipap/nipap.conf
+			sed -e "s/{{DB_HOST}}/$DB_HOST/" -i /etc/nipap/nipap.conf
 		fi
 
 		# create group / user for nipapd

--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -46,10 +46,10 @@
 #group = nipap
 
 
-listen = 127.0.0.1              ; IP address to listen on.
+listen = {{LISTEN_ADDRESS}}      ; IP address to listen on.
 # The default is to listen to 127.0.0.1. Use 0.0.0.0 to listen on all addresses
 # (change requires restart).
-port = 1337                     ; XML-RPC listen port (change requires restart)
+port = {{LISTEN_PORT}}          ; XML-RPC listen port (change requires restart)
 
 foreground = false              ; run in foreground, won't work with init script
 debug = false                   ; enable debug logging
@@ -59,7 +59,7 @@ fork = 0                        ; number of forks
 # determine number of forks (same as number of CPUs). -1 = no forking, >0 =
 # number of forks
 
-syslog = true                   ; log to syslog
+syslog = {{SYSLOG}}             ; log to syslog
 
 pid_file = /var/run/nipap/nipapd.pid
 
@@ -70,7 +70,7 @@ pid_file = /var/run/nipap/nipapd.pid
 # backend database
 #
 
-db_host = localhost            ; database hostname
+db_host = {{DB_HOST}}           ; database hostname
 # The default is to connect via IP to localhost. This is preferred over
 # connecting over a UNIX socket as it supports MD5 authentication.
 # "" (ie, empty string without quotes), is a special case which means to
@@ -78,14 +78,14 @@ db_host = localhost            ; database hostname
 # using "ident" support so the user nipapd is run as needs to match with the
 # database username.
 
-db_port = 5432                  ; port that PostgreSQL listens to, defaults to
+db_port = {{DB_PORT}}           ; port that PostgreSQL listens to, defaults to
 # 5432, only applicable if connection is not over a UNIX socket
 
-db_name = nipap                 ; database name
-db_user = nipap                 ; database username
-db_pass = papin                 ; database password
+db_name = {{DB_NAME}}           ; database name
+db_user = {{DB_USERNAME}}       ; database username
+db_pass = {{DB_PASSWORD}}       ; database password
 
-db_sslmode = require            ; database SSL mode
+db_sslmode = {{DB_SSLMODE}}     ; database SSL mode
 # please see the PostgreSQL database documentation for further details
 
 


### PR DESCRIPTION
I've switched out some of the values that we want to substitue to Jinja2
style variables so that it's easier to use, well, Jinja2 to do the
rendering of the config file.

This is kind of preparatory work for putting nipapd in a docker
container as I envision using envtpl to do the variable subsitution.

The debian nipapd postinst script is however still using sed since I
didn't want to include envtpl in the normal debian package and I'm too
lazy to write a Jinja2 renderer right now. This should still be better
than before IMHO.

Fixes #949.