### PR TITLE
docker nipapd: Clean up after apt

### DIFF
--- a/Dockerfile.nipapd
+++ b/Dockerfile.nipapd
@@ -48,9 +48,10 @@ RUN apt-get update -qy && apt-get upgrade -qy \
     python-all \
     python-docutils \
     python-pip \
-    python-dev
+    python-dev \
+ && pip --no-input install envtpl
+ && rm -rf /var/lib/apt/lists/*
 
-RUN pip --no-input install envtpl
 
 COPY nipap /nipap
 WORKDIR /nipap


### PR DESCRIPTION
This should reduce the size of the resulting docker image slightly as
well as removing unecessary layers.