### PR TITLE
Bump Python dependency to 2.7

### DIFF
--- a/nipap-cli/debian/control
+++ b/nipap-cli/debian/control
@@ -2,12 +2,12 @@ Source: nipap-cli
 Maintainer: Lukas Garberg <lukas@spritelink.net>
 Section: python
 Priority: optional
-Build-Depends: python (>= 2.4), debhelper (>= 7), python-all
+Build-Depends: python (>= 2.7), debhelper (>= 7), python-all
 Standards-Version: 3.9.1
 
 Package: nipap-cli
 Architecture: all
-Depends: ${misc:Depends}, python (>= 2.4), python-ipy, python-pynipap
+Depends: ${misc:Depends}, python (>= 2.7), python-ipy, python-pynipap
 Description: Neat IP Address Planner
  The Neat IP Address Planner, NIPAP, is a system built for efficiently managing
  large amounts of IP addresses. This is the shell command.

--- a/nipap-www/debian/control
+++ b/nipap-www/debian/control
@@ -3,12 +3,12 @@ Section: web
 Priority: optional
 Maintainer: Lukas Garberg <lukas@spritelink.net>
 Build-Depends: debhelper (>= 5.0.38), debhelper (>= 7),
- python (>= 2.4), python-setuptools (>= 0.6b3)
+ python (>= 2.7), python-setuptools (>= 0.6b3)
 Standards-Version: 3.9.1
 
 Package: nipap-www
 Architecture: all
-Depends: debconf, python (>= 2.4), ${misc:Depends}, python-pylons (>=1.0), python-pynipap, nipap-common, python-jinja2
+Depends: debconf, python (>= 2.7), ${misc:Depends}, python-pylons (>=1.0), python-pynipap, nipap-common, python-jinja2
 XB-Python-Version: ${python:Versions}
 Description: web frontend for NIPAP
  A web UI for the NIPAP IP address planning service.

--- a/pynipap/debian/control
+++ b/pynipap/debian/control
@@ -3,15 +3,15 @@ Maintainer: Lukas Garberg <lukas@spritelink.net>
 Section: python
 Priority: optional
 Build-Depends: debhelper (>= 8), dh-python,
-               python (>= 2.4),
+               python (>= 2.7),
                python3 (>= 3.1)
-X-Python-Version: >= 2.4
+X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.1
 Standards-Version: 3.9.6
 
 Package: python-pynipap
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}
+Depends: ${misc:Depends}, python (>= 2.7)
 Breaks: ${python:Breaks}
 Description: Python module for accessing NIPAP
  This package contains a client library for NIPAP. It's function is similar to
@@ -20,7 +20,7 @@ Description: Python module for accessing NIPAP
 
 Package: python3-pynipap
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}
+Depends: ${misc:Depends}, python3 (>= 3.1)
 Breaks: ${python3:Breaks}
 Description: Python 3 module for accessing NIPAP
  This package contains a client library for NIPAP. It's function is similar to


### PR DESCRIPTION
Bumped the Python dependency from 2.4 (which probably cannot even run the relevant code) to 2.7. I've previously pushed for 2.6, but f*ckit. Debian has been shipped with 2.7 since wheezy, which was released in May 2013.

Also changed the Python dependency in the pynipap package to a specific version to avoid letting the resulting dependency vary with the build system.