### PR TITLE
backend: Add prefix_length to prefix smart parser

### DIFF
--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -406,6 +406,7 @@ class PrefixSmartParser(SmartParser):
         'order_id': True,
         'pool': True,
         'prefix': True,
+        'prefix_length': True,
         'status': True,
         'total_addresses': True,
         'type': True,


### PR DESCRIPTION
Added the prefix_length field to the prefix smart parser module.

Fixes #973