### PR TITLE
Handle new interpretation format in VRF filter

### DIFF
--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -964,7 +964,7 @@ function receiveVRFSelector(result) {
 	// If it's a search for the default VRF, ie empty search, then display the
 	// currently selected VRFs. For other search, we don't show the currently
 	// selected to avoid cluttering the result list.
-	if (result.interpretation.length == 1 && result.interpretation[0].string == '') {
+	if ($('input[name="vrf_search_string"]').val() == "") {
 		// add selected VRFs to the selectedbar
 		$.each(selected_vrfs, function (k, v) {
 			// except for the default VRF, since that will already be included
@@ -1028,7 +1028,7 @@ function clickFilterVRFSelector(evt) {
 	var tgt = evt.target;
 	while (true) {
 		if (tgt.hasAttribute('data-vrf_id')) {
-			break
+			break;
 		}
 		tgt = tgt.parentElement;
 	}


### PR DESCRIPTION
The VRF filter (list of currently selected VRFs which is used as an additional search filter for the prefix searches) was not modified for the new smart search interpretation format.

The change introduced relies on that the search result returned refers to the search string currently entered. This is not always the case as the user can change the query string while the response is received. For this case, when we need to figure out whether the query was empty so we can append the selected VRFs to the list, this is not a problem, but it strikes me that it might be beneficial to add the full query string to the result as well? Now only the parsed, sliced and diced version is returned in the interpretation.