### PR TITLE
Correct redeploy path

### DIFF
--- a/nso-nipap/nso-nipap/src/java/src/net/spritelink/nsonipap/ConfigCdbSub.java
+++ b/nso-nipap/nso-nipap/src/java/src/net/spritelink/nsonipap/ConfigCdbSub.java
@@ -184,7 +184,7 @@ public class ConfigCdbSub implements ApplicationComponent {
 						try {
 							ConfValue redeployPath = maapi.getElem(th, req.path + "/redeploy-service");
 							LOGGER.info("redeploy-service: " + redeployPath);
-							redeploy(redeployPath + "/re-deploy");
+							redeploy(redeployPath.toString());
 						} catch (Exception e) {
 						}
                     }


### PR DESCRIPTION
Obviously something just went too fast. The changes to how redeploys are performed which I committed are broken (a part of the redeploy path from the example I copied wasn't removed which resulted in an incorrect redeploy path).

This PR addresses that issue.