### PR TITLE
Fix installation path of CLI

### DIFF
--- a/nipap-cli/debian/rules
+++ b/nipap-cli/debian/rules
@@ -1,8 +1,8 @@
 #!/usr/bin/make -f
 
-PYBUILD_NAME = nipap-cli
+#export DH_VERBOSE=1
+export PYBUILD_NAME=nipap-cli
+export PYBUILD_INSTALL_ARGS=--install-lib usr/lib/python3/dist-packages/
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-
-


### PR DESCRIPTION
With the introduction of the pybuild build system, python3 packages not either being named python3-* or depending on ${python3:Depends} gets their modules installed in a python version specific directory (in my case /usr/lib/python3.5/dist-packages). This is not very suitable for a package which should be possible to run with different versions of python3.

The fix implemented is to simply tell the python setup script to install the packages into a non version specific directory, in this case /usr/lib/python3/dist-packages. A bit of a hackish solution, but given
how pybuild works I found no cleaner solution.

Fixes #1003 