### PR TITLE
www: Handle top-level error flag from smart_search

### DIFF
--- a/nipap-www/nipapwww/controllers/xhr.py
+++ b/nipap-www/nipapwww/controllers/xhr.py
@@ -109,6 +109,12 @@ class XhrController(BaseController):
             result = VRF.smart_search(request.params['query_string'],
                 search_options, extra_query
                 )
+            # Remove error key in result from backend as it interferes with the
+            # error handling of the web interface.
+            # TODO: Reevaluate how to deal with different types of errors; soft
+            # errors like query string parser errors and hard errors like lost
+            # database.
+            del result['error']
         except NipapError, e:
             return json.dumps({'error': 1, 'message': e.args, 'type': type(e).__name__})
 
@@ -233,6 +239,12 @@ class XhrController(BaseController):
             result = Pool.smart_search(request.params['query_string'],
                 search_options
                 )
+            # Remove error key in result from backend as it interferes with the
+            # error handling of the web interface.
+            # TODO: Reevaluate how to deal with different types of errors; soft
+            # errors like query string parser errors and hard errors like lost
+            # database.
+            del result['error']
         except NipapError, e:
             return json.dumps({'error': 1, 'message': e.args, 'type': type(e).__name__})
 
@@ -496,6 +508,12 @@ class XhrController(BaseController):
         try:
             result = Prefix.smart_search(request.params['query_string'],
                 search_options, extra_query)
+            # Remove error key in result from backend as it interferes with the
+            # error handling of the web interface.
+            # TODO: Reevaluate how to deal with different types of errors; soft
+            # errors like query string parser errors and hard errors like lost
+            # database.
+            del result['error']
         except NipapError, e:
             return json.dumps({'error': 1, 'message': e.args, 'type': type(e).__name__})
 


### PR DESCRIPTION
The "top-level" error flag newly introduced in the smart_search_-functions collided with an error flag used by the web interface. This is a quick fix for that issue which simply removes the error key from the result received from smart_search. The flag is currently only used to signal query string parser errors, which also are present deeper in the interpretation dict where it will be picked up and displayed by the web UI. Thus no functionality is lost when the top-level flag is removed.

I was probably a bit too quick implementing the error flag; we should probably think through how to convey "soft errors" (such as string parsing errors) vs "hard errors" (such as, for example, the backend
being unable to reach the database) and how to do it in a future JSON-based REST API.

Fixes #1004.