### PR TITLE
Dockerify nipap-www

### DIFF
--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -1,0 +1,61 @@
+# This file describes a docker image for running nipap-www in docker
+#
+# Build the docker image:
+#     docker build -t nipap-www -f Dockerfile.www .
+#
+# Run by linking to the container running nipapd. -i -t is for interactive,
+# use -d if you wish to run the container in the background:
+#     docker run -i -t --link nipapd --name nipap-www nipap-www
+#
+# Most configuration variables are provided via environment variables.
+#   NIPAPD_USERNAME     username to authenticate to nipapd
+#   NIPAPD_PASSWORD     password to authenticate to nipapd
+#   NIPAPD_HOST         host where nipapd is running [nipapd]
+#   NIPAPD_PORT         port of nipapd [1337]
+#   WWW_USERNAME        web UI username [guest]
+#   WWW_PASSWORD        web UI password [guest]
+#
+# Some variables have a default, indicated in square brackets, the rest you need
+# to fill in. If you are linking to a container running nipapd, just enter the
+# name of the container as NIPAPD_HOST.
+#
+# WWW_USERNAME & WWW_PASSWORD is used to create a new account in the local auth
+# database so that you can later login to the web interface.
+#
+
+FROM ubuntu:xenial
+
+MAINTAINER Lukas Garberg <lukas@spritelink.net>
+
+ENV NIPAPD_HOST=nipapd NIPAPD_PORT=1337 WWW_USERNAME=guest WWW_PASSWORD=guest
+
+# apt update, upgrade & install packages
+RUN apt-get update -qy && apt-get upgrade -qy \
+ && apt-get install -qy apache2 \
+    libapache2-mod-wsgi \
+    devscripts \
+    make \
+    libpq-dev \
+    libsqlite3-dev \
+    postgresql-client \
+    python \
+    python-all \
+    python-docutils \
+    python-pip \
+    python-dev \
+ && pip --no-input install envtpl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install pynipap, nipap and nipap-www
+COPY pynipap /pynipap
+COPY nipap /nipap
+COPY nipap-www /nipap-www
+RUN cd /pynipap && python setup.py install && \
+    cd /nipap && pip --no-input install -r requirements.txt && python setup.py install && \
+    cd /nipap-www && pip --no-input install -r requirements.txt && python setup.py install && \
+    cd ..
+
+EXPOSE 80
+VOLUME [ "/var/log/apache2" ]
+
+ENTRYPOINT [ "/nipap-www/entrypoint.sh" ]

--- a/nipap-www/entrypoint.sh
+++ b/nipap-www/entrypoint.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+# Create NIPAP configuration file
+envtpl --keep-template --allow-missing -o /etc/nipap/nipap.conf /nipap/nipap.conf.dist
+
+# Set up local auth database
+if [ ! -e /etc/nipap/local_auth.db ]; then
+    /usr/sbin/nipap-passwd create-database
+fi
+if [ `nipap-passwd list | egrep -c ^$WWW_USERNAME\\\s` -eq 0 ]; then
+    /usr/sbin/nipap-passwd add -u $WWW_USERNAME -p $WWW_PASSWORD -n "NIPAP WWW user" -t
+fi
+
+# Fix permissions
+chown -R www-data:www-data /var/cache/nipap-www
+chmod -R u=rwX /var/cache/nipap-www
+
+# Configure apache
+cat << EOF > /etc/apache2/sites-available/000-default.conf
+<VirtualHost *:80>
+    WSGIScriptAlias / /etc/nipap/nipap-www.wsgi
+    ErrorLog \${APACHE_LOG_DIR}/error.log
+    CustomLog \${APACHE_LOG_DIR}/access.log combined
+    <Directory /etc/nipap>
+        Require all granted
+    </Directory>
+</VirtualHost>
+EOF
+
+# Start apache
+source /etc/apache2/envvars
+exec /usr/sbin/apache2 -DFOREGROUND

--- a/nipap/entrypoint.sh
+++ b/nipap/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-envtpl /nipap/nipap.conf.dist -o /etc/nipap/nipap.conf
+envtpl --allow-missing /nipap/nipap.conf.dist -o /etc/nipap/nipap.conf
 
 /usr/sbin/nipap-passwd create-database
 if [ -n "$NIPAP_USERNAME" -a -n "$NIPAP_PASSWORD" ]; then

--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -176,7 +176,7 @@ db_path = /etc/nipap/local_auth.db     ; path to SQLite database used
 # ----------------------
 #
 [www]
-xmlrpc_uri = http://@:@127.0.0.1:1337
+xmlrpc_uri = http://{{NIPAPD_USERNAME}}:{{NIPAPD_PASSWORD}}@{{NIPAPD_HOST}}:{{NIPAPD_PORT}}
 #connection uri to the backend
 #example using local authentication with username 'user' and password 'pass'
 #xmlrpc_uri = http://user@local:pass@127.0.0.1:1337


### PR DESCRIPTION
Added a dockerfile and entrypoint-script for nipap-www. It's based on a standard ubuntu:xenial-image, serving the NIPAP web UI with apache2 with mod_wsgi.

All installation of dependencies and NIPAP packages is done in the dockerfile, while the local auth database is setup, permissions are corrected and apache2 configured in the entrypoint shell script. The
dockerfile currently doesn't provide any way to make changes to the nipap-www.ini-file.