### PR TITLE
Fix prefix smart search with tags

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -200,8 +200,8 @@ def _parse_interp_pool(query, indent=-5, pandop=False):
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
+        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
 
     else:
         text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
@@ -327,8 +327,8 @@ def _parse_interp_vrf(query, indent=-5, pandop=False):
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
+        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
 
     else:
         text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
@@ -428,8 +428,8 @@ def _parse_interp_prefix(query, indent=-5, pandop=False):
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string']
+        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
 
     elif interp['attribute'] == 'prefix' and interp['operator'] == 'contained_within_equals':
         if 'strict_prefix' in interp and 'expanded' in interp:

--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -1170,8 +1170,8 @@ function parseInterp(query, container) {
 		} else if (interp.interpretation == 'and') {
 			text = "<b>AND</b>";
 		} else if (interp.attribute == 'tag' && interp.operator == 'equals_any') {
-			text += ' must contain <b>' + interp.string + '</b>';
-			tooltip = "The tag(s) or inherited tag(s) must contain " + interp.string;
+			text += ' must contain <b>' + interp.string.slice(1) + '</b>';
+			tooltip = "The tag(s) or inherited tag(s) must contain " + interp.string.slice(1);
 		} else if (interp.attribute == 'prefix' && interp.operator == 'contained_within_equals') {
 			text += ' within ';
 			if ('strict_prefix' in interp && 'expanded' in interp) {

--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -338,7 +338,7 @@ class PoolSmartParser(SmartParser):
         self._logger.debug("parsing string: " + str(part[0]) + " of type: " + part.getName())
 
         if part.getName() == 'tag':
-            self._logger.debug("Query part '" + part[0][0] + "' interpreted as tag")
+            self._logger.debug("Query part '" + part[0] + "' interpreted as tag")
             dictsql = {
                     'interpretation': {
                         'string': part[0],
@@ -456,10 +456,10 @@ class PrefixSmartParser(SmartParser):
         self._logger.debug("parsing string: " + str(part[0]) + " of type: " + part.getName())
 
         if part.getName() == 'tag':
-            self._logger.debug("Query part '" + part[0][0] + "' interpreted as tag")
+            self._logger.debug("Query part '" + part[0] + "' interpreted as tag")
             dictsql = {
                     'interpretation': {
-                        'string': part[0][0],
+                        'string': part[0],
                         'interpretation': 'tag',
                         'attribute': 'tag',
                         'operator': 'equals_any',
@@ -467,7 +467,7 @@ class PrefixSmartParser(SmartParser):
                         },
                     'operator': 'equals_any',
                     'val1': 'tags',
-                    'val2': part[0]['word']
+                    'val2': part[0][1:]
                     }
 
         elif part.getName() == 'vrf_rt':
@@ -650,7 +650,7 @@ class VrfSmartParser(SmartParser):
         self._logger.debug("parsing string: " + str(part[0]) + " of type: " + part.getName())
 
         if part.getName() == 'tag':
-            self._logger.debug("Query part '" + part[0][0] + "' interpreted as tag")
+            self._logger.debug("Query part '" + part[0] + "' interpreted as tag")
             dictsql = {
                     'interpretation': {
                         'string': part[0],

--- a/tests/nipaptest.py
+++ b/tests/nipaptest.py
@@ -121,7 +121,7 @@ class TestPrefixExpires(unittest.TestCase):
 
         # test the relative time parsing of the backend by setting "tomorrow",
         # which parsedatetime interprets as 09:00 the next day
-        # 
+        #
         tomorrow = datetime.datetime.now().replace(hour = 9, minute = 0,
                 second = 0, microsecond = 0) + datetime.timedelta(days = 1)
         p1.expires = "tomorrow"
@@ -2469,6 +2469,30 @@ class TestSmartParser(unittest.TestCase):
 
 
 
+    def test_prefix18(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+
+        success, query = n._parse_prefix_query('#foo')
+
+        expected = {
+            'interpretation': {
+                'attribute': 'tag',
+                'error': False,
+                'interpretation': 'tag',
+                'operator': 'equals_any',
+                'string': '#foo'
+            },
+            'operator': 'equals_any',
+            'val1': 'tags',
+            'val2': 'foo'
+        }
+
+        self.assertEqual(success, True)
+        self.assertEqual(query, expected)
+
+
+
     def test_vrf1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
@@ -2709,6 +2733,30 @@ class TestSmartParser(unittest.TestCase):
 
 
 
+    def test_vrf7(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+
+        success, query = n._parse_vrf_query('#foo')
+
+        expected = {
+            'interpretation': {
+                'attribute': 'tag',
+                'error': False,
+                'interpretation': 'tag',
+                'operator': 'equals_any',
+                'string': '#foo'
+            },
+            'operator': 'equals_any',
+            'val1': 'tags',
+            'val2': 'foo'
+        }
+
+        self.assertEqual(success, True)
+        self.assertEqual(query, expected)
+
+
+
     def test_pool1(self):
         cfg = NipapConfig('/etc/nipap/nipap.conf')
         n = Nipap()
@@ -2906,6 +2954,31 @@ class TestSmartParser(unittest.TestCase):
 
         self.assertEqual(success, True)
         self.assertEqual(query, exp_query)
+
+
+
+    def test_pool7(self):
+        cfg = NipapConfig('/etc/nipap/nipap.conf')
+        n = Nipap()
+
+        success, query = n._parse_pool_query('#foo')
+
+        expected = {
+            'interpretation': {
+                'attribute': 'tag',
+                'error': False,
+                'interpretation': 'tag',
+                'operator': 'equals_any',
+                'string': '#foo'
+            },
+            'operator': 'equals_any',
+            'val1': 'tags',
+            'val2': 'foo'
+        }
+
+        self.assertEqual(success, True)
+        self.assertEqual(query, expected)
+
 
 
 class TestAvpEmptyName(unittest.TestCase):


### PR DESCRIPTION
Fix prefix smart search where the search string contains tags and adjust debug logging statements to display the correct value.

Also adjusted how the search interpretation is displayed slightly.

Before:
```#foo: tag must contain #foo``` - a bit misleading as the tag name in this case actually is ```foo```, without hash.

After:
```#foo: tag must contain foo``` - correct as the tag name is ```foo```.

Fixes #1008.