### PR TITLE
Improve handling of extra attributes with empty values

### DIFF
--- a/nipap-www/nipapwww/public/controllers.js
+++ b/nipap-www/nipapwww/public/controllers.js
@@ -403,7 +403,9 @@ nipapAppControllers.controller('PrefixAddController', function ($scope, $routePa
 		// Mangle avps
 		query_data.avps = {};
 		$scope.prefix.avps.forEach(function(avp) {
-			query_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				query_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		query_data.avps = JSON.stringify(query_data.avps);
 
@@ -609,7 +611,9 @@ nipapAppControllers.controller('PrefixEditController', function ($scope, $routeP
 		// Mangle avps
 		prefix_data.avps = {};
 		$scope.prefix.avps.forEach(function(avp) {
-			prefix_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				prefix_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		prefix_data.avps = JSON.stringify(prefix_data.avps);
 
@@ -687,7 +691,9 @@ nipapAppControllers.controller('VRFAddController', function ($scope, $http) {
 		query_data.tags = JSON.stringify($scope.vrf.tags.map(function (elem) { return elem.text; }));
 		query_data.avps = {};
 		$scope.vrf.avps.forEach(function(avp) {
-			query_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				query_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		query_data.avps = JSON.stringify(query_data.avps);
 
@@ -812,7 +818,9 @@ nipapAppControllers.controller('VRFEditController', function ($scope, $routePara
 		query_data.tags = JSON.stringify($scope.vrf.tags.map(function (elem) { return elem.text; }));
 		query_data.avps = {};
 		$scope.vrf.avps.forEach(function(avp) {
-			query_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				query_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		query_data.avps = JSON.stringify(query_data.avps);
 
@@ -879,7 +887,9 @@ nipapAppControllers.controller('PoolAddController', function ($scope, $http) {
 		// Mangle avps
 		query_data.avps = {};
 		$scope.pool.avps.forEach(function(avp) {
-			query_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				query_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		query_data.avps = JSON.stringify(query_data.avps);
 
@@ -1065,7 +1075,9 @@ nipapAppControllers.controller('PoolEditController', function ($scope, $routePar
 		// Mangle avps
 		query_data.avps = {};
 		$scope.pool.avps.forEach(function(avp) {
-			query_data.avps[avp.attribute] = avp.value;
+			if (avp.attribute != '' && avp.value != '') {
+				query_data.avps[avp.attribute] = avp.value;
+			}
 		});
 		query_data.avps = JSON.stringify(query_data.avps);
 

--- a/nipap-www/nipapwww/public/templates/pool_form.html
+++ b/nipap-www/nipapwww/public/templates/pool_form.html
@@ -140,7 +140,7 @@
 							<tbody>
 								<tr ng-repeat="avp in pool.avps">
 									<td class="col-md-4" style="padding: 0;">
-										<input type="text" style="width: 90%;" ng-model="avp.attribute"> <b>=</b>
+										<input type="text" style="width: 90%;" ng-model="avp.attribute" ng-required="avp.value"> <b>=</b>
 									</td>
 									<td class="col-md-7" style="padding: 0;">
 										<input type="text" style="width: 100%;" ng-model="avp.value">

--- a/nipap-www/nipapwww/public/templates/prefix_form.html
+++ b/nipap-www/nipapwww/public/templates/prefix_form.html
@@ -300,7 +300,7 @@ PREFIX DATA
 							<tbody>
 							<tr ng-repeat="avp in prefix.avps">
 								<td class="col-md-4" style="padding: 0;">
-									<input type="text" style="width: 90%;" ng-model="avp.attribute"> <b>=</b>
+									<input type="text" style="width: 90%;" ng-model="avp.attribute" ng-required="avp.value"> <b>=</b>
 								</td>
 								<td class="col-md-7" style="padding: 0;">
 									<input type="text" style="width: 100%;" ng-model="avp.value">

--- a/nipap-www/nipapwww/public/templates/vrf_form.html
+++ b/nipap-www/nipapwww/public/templates/vrf_form.html
@@ -87,7 +87,7 @@ VRF DATA
 							<tbody>
 								<tr ng-repeat="avp in vrf.avps">
 									<td class="col-md-4" style="padding: 0;">
-										<input type="text" style="width: 90%;" ng-model="avp.attribute"> <b>=</b>
+										<input type="text" style="width: 90%;" ng-model="avp.attribute" ng-required="avp.value"> <b>=</b>
 									</td>
 									<td class="col-md-7" style="padding: 0;">
 										<input type="text" style="width: 100%;" ng-model="avp.value">


### PR DESCRIPTION
In the web UI, improve the handling of extra attributes with empty values so that:
* Entries where both the attribute and value is empty are removed when sending data to the server.
* The attribute field is mandatory when a value is entered.

Fixes #882.