### PR TITLE
nipapd: mangle IPv4 address

### DIFF
--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -564,9 +564,10 @@ class PrefixSmartParser(SmartParser):
             # search
             elif self._get_afi(part[0]) == 4 and len(part[0].split('.')) == 4:
                 self._logger.debug("Query part '" + part[0] + "' interpreted as prefix")
+                address = str(IPy.IP(part[0]))
                 dictsql = {
                     'interpretation': {
-                        'string': part[0],
+                        'string': address,
                         'interpretation': 'IPv4 address',
                         'attribute': 'prefix',
                         'operator': 'contains_equals',
@@ -574,7 +575,7 @@ class PrefixSmartParser(SmartParser):
                     },
                     'operator': 'contains_equals',
                     'val1': 'prefix',
-                    'val2': part[0]
+                    'val2': address
                 }
 
             else:


### PR DESCRIPTION
This mangles IPv4 address in search queries through IPy to get a
properly formatted IPv4 address before we send it to Postgres. We do
validation of IPv4 addresses but once they are verified we send the
original value, so for example 10.18.01.1 is recognized as IPv4 but
Postgres doesn't like the leading 0 in the third octet. By running it
through IPy we get rid of that leading 0 and all is fine.

Fixes #860.