### PR TITLE
www: Update extend-diff-ignore

### DIFF
--- a/nipap-www/debian/source/options
+++ b/nipap-www/debian/source/options
@@ -1,2 +1,2 @@
 # Keep a few files out of the debian package
-extend-diff-ignore = "(^|/)(test.ini|Makefile|data/sessions/container_file/.*|data/sessions/container_file_lock/.*)$"
+extend-diff-ignore = "(^|/)(test.ini|Makefile|data/sessions/container_file/.*|data/sessions/container_file_lock/.*|requirements.txt|entrypoint.sh)$"


### PR DESCRIPTION
Update extend-diff-ignore for the nipap-www debian package to ignore last additions: requirements.txt and entrypoint.txt.