### PR TITLE
www: Add slash to generated URI

### DIFF
--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -440,7 +440,7 @@ function setSearchPrefixURI() {
 		url_str += '?' + url.attr('query');
 	}
 
-	url_str += '#query_string=' +
+	url_str += '#/query_string=' +
 		encodeURIComponent($('#query_string').val()) +
 		'&search_opt_parent=' +
 		encodeURIComponent($('input[name="search_opt_parent"]:checked').val()) +


### PR DESCRIPTION
After the AngularJS upgrade from v1.3.15 to v1.5.3 a slash has been introduced in the URI from some reason. The code in NIPAP which stores the current search state in the URI neeed to be updated to reflect this, to avoid the page from reloading when opening the VRF selector.

Fixes #1029.