### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/nipap-cli/nipap_cli/command.py
+++ b/nipap-cli/nipap_cli/command.py
@@ -178,7 +178,7 @@ class Command:
         option_parsing = False
         self._scoop_rest_arguments = False
 
-        if inp_cmd != None:
+        if inp_cmd is not None:
             self.inp_cmd = inp_cmd
 
         # iterate the list of inputted commands

--- a/nipap-www/nipapwww/controllers/prefix.py
+++ b/nipap-www/nipapwww/controllers/prefix.py
@@ -91,7 +91,7 @@ class PrefixController(BaseController):
                 # TODO: handle non-existent VRF...
                 c.prefix.vrf = VRF.list({ 'rt': request.params['prefix_vrf'] })[0]
 
-            if request.params.get('prefix_monitor') != None:
+            if request.params.get('prefix_monitor') is not None:
                 c.prefix.monitor = True
             else:
                 c.prefix.monitor = False

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -1953,7 +1953,7 @@ class Nipap:
             p = dict(row)
 
             # Make sure that prefixes is a list, even if there are no prefixes
-            if p['prefixes'] == None:
+            if p['prefixes'] is None:
                 p['prefixes'] = []
             res.append(p)
 
@@ -2428,7 +2428,7 @@ class Nipap:
             if query['operator'] not in _operation_map:
                 raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
 
-            if query['val1'] == 'vrf_id' and query['val2'] == None:
+            if query['val1'] == 'vrf_id' and query['val2'] is None:
                 query['val2'] = 0
 
             # workaround for handling equal matches of NULL-values


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SpriteLink:NIPAP?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:SpriteLink:NIPAP?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)