### PR TITLE
Accept parent_prefix as None

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -3383,7 +3383,8 @@ class Nipap:
                     ''' 'offset'. Only integer values allowed.''')
 
         # parent_prefix
-        if 'parent_prefix' not in search_options:
+        if ('parent_prefix' not in search_options or
+                search_options['parent_prefix'] is None):
             search_options['parent_prefix'] = None
         else:
             try:


### PR DESCRIPTION
It won't do anything but at least we avoid throwing an exception. This
can be useful if someone wants to feed the search_options returned by a
query into another query.

Fixes #998.