### PR TITLE
Remove landscape config file

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,2 +1,0 @@
-requirements:
-  - nipap/requirements.txt


### PR DESCRIPTION
landscape.io doesn't correctly run it checks and I'm tired of fiddling
around with it. Rather stick to QuantifiedCode and HoundCI for the time
being, thus removing the Landscape.io config file.