### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -71,7 +71,7 @@ def setup_connection():
         con_params['password'] = getpass.getpass()
 
     # build XML-RPC URI
-    pynipap.xmlrpc_uri = "http://%(username)s:%(password)s@%(hostname)s:%(port)s" % con_params
+    pynipap.xmlrpc_uri = "http://{username!s}:{password!s}@{hostname!s}:{port!s}".format(**con_params)
 
     ao = pynipap.AuthOptions({
         'authoritative_source': 'nipap',
@@ -82,7 +82,7 @@ def setup_connection():
 
 
 def vrf_format(vrf):
-    return "VRF '%s' [RT: %s]" % (vrf.name, vrf.rt or '-')
+    return "VRF '{0!s}' [RT: {1!s}]".format(vrf.name, vrf.rt or '-')
 
 
 def get_pool(arg = None, opts = None, abort = False):
@@ -97,7 +97,7 @@ def get_pool(arg = None, opts = None, abort = False):
         pool = Pool.list({ 'name': arg })[0]
     except IndexError:
         if abort:
-            print("Pool '%s' not found." % str(arg), file=sys.stderr)
+            print("Pool '{0!s}' not found.".format(str(arg)), file=sys.stderr)
             sys.exit(1)
         else:
             pool = None
@@ -146,7 +146,7 @@ def get_vrf(arg = None, default_var = 'default_vrf_rt', abort = False):
                 })['result'][0]
         except (KeyError, IndexError):
             if abort:
-                print("VRF with [RT: %s] not found." % str(vrf_rt), file=sys.stderr)
+                print("VRF with [RT: {0!s}] not found.".format(str(vrf_rt)), file=sys.stderr)
                 sys.exit(1)
             else:
                 vrf = False
@@ -189,35 +189,35 @@ def _parse_interp_pool(query, indent=-5, pandop=False):
     if interp.get('error') is True and interp['operator'] is None:
 
         if interp['error_message'] == 'unclosed quote':
-            text = "%s: %s, please close quote!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close quote!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of quotes."
 
         elif interp['error_message'] == 'unclosed parentheses':
-            text = "%s: %s, please close parentheses!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close parentheses!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of parentheses."
 
     elif interp['operator'] in ['and', 'or']:
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
+        text = "{0!s}: {1!s} must contain {2!s}".format(interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain {0!s}".format(interp['string'][1:])
 
     else:
-        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
+        text = "{0!s}: {1!s} matching {2!s}".format(interp['string'], interp['interpretation'], interp['string'])
 
     # "Minor" error messages, string could be parsed but contain errors
     if interp.get('error') is True and interp['operator'] is not None: # .get() for backwards compatibiliy
         if interp['error_message'] == 'invalid value':
             text += ": invalid value!"
-            text2 = "The value provided is not valid for the attribute '%s'." % interp['attribute']
+            text2 = "The value provided is not valid for the attribute '{0!s}'.".format(interp['attribute'])
 
         elif interp['error_message'] == 'unknown attribute':
-            text += ": unknown attribute '%s'!" % interp['attribute']
-            text2 = "There is no pool attribute '%s'." % interp['attribute']
+            text += ": unknown attribute '{0!s}'!".format(interp['attribute'])
+            text2 = "There is no pool attribute '{0!s}'.".format(interp['attribute'])
 
         else:
-            text += ": %s, invalid query" % interp['error_message']
+            text += ": {0!s}, invalid query".format(interp['error_message'])
             text2 = "This is not a proper search query."
 
     if text:
@@ -227,9 +227,9 @@ def _parse_interp_pool(query, indent=-5, pandop=False):
                 a = ' `-- '
             print("{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text))
         else:
-            print("%s       `-- %s" % (' '*indent, text))
+            print("{0!s}       `-- {1!s}".format(' '*indent, text))
     if text2:
-        print("%s   %s" % (' '*indent, text2))
+        print("{0!s}   {1!s}".format(' '*indent, text2))
     if type(query['val1']) is dict:
         _parse_interp_pool(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
@@ -265,14 +265,14 @@ def list_pool(arg, opts, shell_opts):
                 _parse_interp_pool(res['interpretation'])
 
             if res['error']:
-                print("Query failed: %s" % res['error_message'])
+                print("Query failed: {0!s}".format(res['error_message']))
                 return
 
             if len(res['result']) == 0:
                 print("No matching pools found")
                 return
 
-            print("%-19s %-2s %-39s %-13s  %-8s %s" % (
+            print("{0:<19!s} {1:<2!s} {2:<39!s} {3:<13!s}  {4:<8!s} {5!s}".format(
                 "Name", "#", "Description", "Default type", "4 / 6", "Implied VRF"
                 ))
             print("------------------------------------------------------------------------------------------------")
@@ -291,9 +291,9 @@ def list_pool(arg, opts, shell_opts):
 
             tags = '-'
             if len(p.tags) > 0:
-                tags = "#%d" % (len(p.tags))
+                tags = "#{0:d}".format((len(p.tags)))
 
-            print("%-19s %-2s %-39s %-13s %-2s / %-3s  [RT: %s] %s" % (
+            print("{0:<19!s} {1:<2!s} {2:<39!s} {3:<13!s} {4:<2!s} / {5:<3!s}  [RT: {6!s}] {7!s}".format(
                 p.name, tags, desc, p.default_type,
                 str(p.ipv4_default_prefix_length or '-'),
                 str(p.ipv6_default_prefix_length or '-'),
@@ -316,35 +316,35 @@ def _parse_interp_vrf(query, indent=-5, pandop=False):
     if interp.get('error') is True and interp['operator'] is None:
 
         if interp['error_message'] == 'unclosed quote':
-            text = "%s: %s, please close quote!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close quote!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of quotes."
 
         elif interp['error_message'] == 'unclosed parentheses':
-            text = "%s: %s, please close parentheses!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close parentheses!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of parentheses."
 
     elif interp['operator'] in ['and', 'or']:
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
+        text = "{0!s}: {1!s} must contain {2!s}".format(interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain {0!s}".format(interp['string'][1:])
 
     else:
-        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
+        text = "{0!s}: {1!s} matching {2!s}".format(interp['string'], interp['interpretation'], interp['string'])
 
     # "Minor" error messages, string could be parsed but contain errors
     if interp.get('error') is True and interp['operator'] is not None: # .get() for backwards compatibiliy
         if interp['error_message'] == 'invalid value':
             text += ": invalid value!"
-            text2 = "The value provided is not valid for the attribute '%s'." % interp['attribute']
+            text2 = "The value provided is not valid for the attribute '{0!s}'.".format(interp['attribute'])
 
         elif interp['error_message'] == 'unknown attribute':
-            text += ": unknown attribute '%s'!" % interp['attribute']
-            text2 = "There is no pool attribute '%s'." % interp['attribute']
+            text += ": unknown attribute '{0!s}'!".format(interp['attribute'])
+            text2 = "There is no pool attribute '{0!s}'.".format(interp['attribute'])
 
         else:
-            text += ": %s, invalid query" % interp['error_message']
+            text += ": {0!s}, invalid query".format(interp['error_message'])
             text2 = "This is not a proper search query."
 
     if text:
@@ -354,9 +354,9 @@ def _parse_interp_vrf(query, indent=-5, pandop=False):
                 a = ' `-- '
             print("{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text))
         else:
-            print("%s       `-- %s" % (' '*indent, text))
+            print("{0!s}       `-- {1!s}".format(' '*indent, text))
     if text2:
-        print("%s   %s" % (' '*indent, text2))
+        print("{0!s}   {1!s}".format(' '*indent, text2))
     if type(query['val1']) is dict:
         _parse_interp_vrf(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
@@ -380,25 +380,25 @@ def list_vrf(arg, opts, shell_opts):
                 _parse_interp_vrf(res['interpretation'])
 
             if res['error']:
-                print("Query failed: %s" % res['error_message'])
+                print("Query failed: {0!s}".format(res['error_message']))
                 return
 
             if len(res['result']) == 0:
-                print("No VRFs matching '%s' found." % search_string)
+                print("No VRFs matching '{0!s}' found.".format(search_string))
                 return
 
-            print("%-16s %-22s %-2s %-40s" % ("VRF RT", "Name", "#", "Description"))
+            print("{0:<16!s} {1:<22!s} {2:<2!s} {3:<40!s}".format("VRF RT", "Name", "#", "Description"))
             print("--------------------------------------------------------------------------------")
 
         for v in res['result']:
             tags = '-'
             if len(v.tags) > 0:
-                tags = '#%d' % len(v.tags)
+                tags = '#{0:d}'.format(len(v.tags))
             if len(str(v.description)) > 100:
                 desc = v.description[0:97] + "..."
             else:
                 desc = v.description
-            print("%-16s %-22s %-2s %-40s" % (v.rt or '-', v.name, tags, desc))
+            print("{0:<16!s} {1:<22!s} {2:<2!s} {3:<40!s}".format(v.rt or '-', v.name, tags, desc))
 
         if len(res['result']) < limit:
             break
@@ -417,67 +417,67 @@ def _parse_interp_prefix(query, indent=-5, pandop=False):
     if interp.get('error') is True and interp['operator'] is None:
 
         if interp['error_message'] == 'unclosed quote':
-            text = "%s: %s, please close quote!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close quote!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of quotes."
 
         elif interp['error_message'] == 'unclosed parentheses':
-            text = "%s: %s, please close parentheses!" % (interp['string'], interp['error_message'])
+            text = "{0!s}: {1!s}, please close parentheses!".format(interp['string'], interp['error_message'])
             text2 = "This is not a proper search term as it contains an uneven amount of parentheses."
 
     elif interp['operator'] in ['and', 'or']:
         andop = True
 
     elif interp['attribute'] == 'tag' and interp['operator'] == 'equals_any':
-        text = "%s: %s must contain %s" % (interp['string'], interp['interpretation'], interp['string'][1:])
-        text2 = "The tag(s) or inherited tag(s) must contain %s" % interp['string'][1:]
+        text = "{0!s}: {1!s} must contain {2!s}".format(interp['string'], interp['interpretation'], interp['string'][1:])
+        text2 = "The tag(s) or inherited tag(s) must contain {0!s}".format(interp['string'][1:])
 
     elif interp['attribute'] == 'prefix' and interp['operator'] == 'contained_within_equals':
         if 'strict_prefix' in interp and 'expanded' in interp:
-            text = "%s: %s within %s" % (interp['string'],
+            text = "{0!s}: {1!s} within {2!s}".format(interp['string'],
                     interp['interpretation'],
                     interp['strict_prefix'])
-            text2 = "Prefix must be contained within %s, which is the base prefix of %s (automatically expanded from %s)." % (interp['strict_prefix'], interp['expanded'], interp['string'])
+            text2 = "Prefix must be contained within {0!s}, which is the base prefix of {1!s} (automatically expanded from {2!s}).".format(interp['strict_prefix'], interp['expanded'], interp['string'])
 
         elif 'strict_prefix' in interp:
-            text = "%s: %s within %s" % (interp['string'],
+            text = "{0!s}: {1!s} within {2!s}".format(interp['string'],
                     interp['interpretation'],
                     interp['strict_prefix'])
-            text2 = "Prefix must be contained within %s, which is the base prefix of %s." % (interp['strict_prefix'], interp['string'])
+            text2 = "Prefix must be contained within {0!s}, which is the base prefix of {1!s}.".format(interp['strict_prefix'], interp['string'])
 
         elif 'expanded' in interp:
-            text = "%s: %s within %s" % (interp['string'],
+            text = "{0!s}: {1!s} within {2!s}".format(interp['string'],
                     interp['interpretation'],
                     interp['expanded'])
-            text2 = "Prefix must be contained within %s (automatically expanded from %s)." % (interp['expanded'], interp['string'])
+            text2 = "Prefix must be contained within {0!s} (automatically expanded from {1!s}).".format(interp['expanded'], interp['string'])
         else:
-            text = "%s: %s within %s" % (interp['string'],
+            text = "{0!s}: {1!s} within {2!s}".format(interp['string'],
                     interp['interpretation'],
                     interp['string'])
-            text2 = "Prefix must be contained within %s." % (interp['string'])
+            text2 = "Prefix must be contained within {0!s}.".format((interp['string']))
 
     elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
-        text = "%s: Prefix that contains %s" % (interp['string'],
+        text = "{0!s}: Prefix that contains {1!s}".format(interp['string'],
                 interp['string'])
 
     elif interp['attribute'] == 'prefix' and interp['operator'] == 'contains_equals':
-        text = "%s: %s equal to %s" % (interp['string'],
+        text = "{0!s}: {1!s} equal to {2!s}".format(interp['string'],
                 interp['interpretation'], interp['string'])
 
     else:
-        text = "%s: %s matching %s" % (interp['string'], interp['interpretation'], interp['string'])
+        text = "{0!s}: {1!s} matching {2!s}".format(interp['string'], interp['interpretation'], interp['string'])
 
     # "Minor" error messages, string could be parsed but contain errors
     if interp.get('error') is True and interp['operator'] is not None: # .get() for backwards compatibiliy
         if interp['error_message'] == 'invalid value':
             text += ": invalid value!"
-            text2 = "The value provided is not valid for the attribute '%s'." % interp['attribute']
+            text2 = "The value provided is not valid for the attribute '{0!s}'.".format(interp['attribute'])
 
         elif interp['error_message'] == 'unknown attribute':
-            text += ": unknown attribute '%s'!" % interp['attribute']
-            text2 = "There is no prefix attribute '%s'." % interp['attribute']
+            text += ": unknown attribute '{0!s}'!".format(interp['attribute'])
+            text2 = "There is no prefix attribute '{0!s}'.".format(interp['attribute'])
 
         else:
-            text += ": %s, invalid query" % interp['error_message']
+            text += ": {0!s}, invalid query".format(interp['error_message'])
             text2 = "This is not a proper search query."
 
     if text:
@@ -487,9 +487,9 @@ def _parse_interp_prefix(query, indent=-5, pandop=False):
                 a = ' `-- '
             print("{ind}{a}AND-- {t}".format(ind=' '*indent, a=a, t=text))
         else:
-            print("%s       `-- %s" % (' '*indent, text))
+            print("{0!s}       `-- {1!s}".format(' '*indent, text))
     if text2:
-        print("%s   %s" % (' '*indent, text2))
+        print("{0!s}   {1!s}".format(' '*indent, text2))
     if type(query['val1']) is dict:
         _parse_interp_prefix(query['val1'], indent+6, andop)
     if type(query['val2']) is dict:
@@ -516,7 +516,7 @@ def list_prefix(arg, opts, shell_opts):
             'val1': 'vrf_rt',
             'val2': v.rt
         }
-    print("Searching for prefixes in %s..." % vrf_text)
+    print("Searching for prefixes in {0!s}...".format(vrf_text))
 
     col_def = {
             'added': { 'title': 'Added' },
@@ -584,11 +584,11 @@ def list_prefix(arg, opts, shell_opts):
                 _parse_interp_prefix(res['interpretation'])
 
             if res['error']:
-                print("Query failed: %s" % res['error_message'])
+                print("Query failed: {0!s}".format(res['error_message']))
                 return
 
             if len(res['result']) == 0:
-                print("No addresses matching '%s' found." % search_string)
+                print("No addresses matching '{0!s}' found.".format(search_string))
                 return
 
             # guess column width by looking at the initial result set
@@ -615,7 +615,7 @@ def list_prefix(arg, opts, shell_opts):
             col_header_data = {}
             # build prefix formatting string
             for colname, col in [(k, col_def[k]) for k in columns]:
-                prefix_str += "{%s:<%d}  " % (colname, col['width'])
+                prefix_str += "{{{0!s}:<{1:d}}}  ".format(colname, col['width'])
                 col_header_data[colname] = col['title']
 
             column_header = prefix_str.format(**col_header_data)
@@ -634,7 +634,7 @@ def list_prefix(arg, opts, shell_opts):
                 # overwrite some columns due to special handling
                 col_data['tags'] = '-'
                 if len(p.tags) > 0:
-                    col_data['tags'] = '#%d' % len(p.tags)
+                    col_data['tags'] = '#{0:d}'.format(len(p.tags))
 
                 try: 
                     col_data['pool_name'] = p.pool.name
@@ -648,7 +648,7 @@ def list_prefix(arg, opts, shell_opts):
                 print(prefix_str.format(**col_data))
 
             except UnicodeEncodeError as e:
-                print("\nCrazy encoding for prefix %s\n" % p.prefix, file=sys.stderr)
+                print("\nCrazy encoding for prefix {0!s}\n".format(p.prefix), file=sys.stderr)
 
         if len(res['result']) < limit:
             break
@@ -712,7 +712,7 @@ def add_prefix(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         p.avps[key] = value
 
@@ -799,7 +799,7 @@ def add_prefix(arg, opts, shell_opts):
             elif p.type == 'host':
                 pass
             else:
-                print("WARNING: Parent prefix is of type 'assignment'. Automatically overriding specified type '%s' with type 'host' for new prefix." % p.type, file=sys.stderr)
+                print("WARNING: Parent prefix is of type 'assignment'. Automatically overriding specified type '{0!s}' with type 'host' for new prefix.".format(p.type), file=sys.stderr)
             p.type = 'host'
 
             # if it's a manually specified prefix
@@ -820,14 +820,14 @@ def add_prefix(arg, opts, shell_opts):
     try:
         p.save(args)
     except NipapError as exc:
-        print("Could not add prefix to NIPAP: %s" % str(exc), file=sys.stderr)
+        print("Could not add prefix to NIPAP: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
     if p.type == 'host':
-        print("Host %s added to %s: %s" % (p.display_prefix,
+        print("Host {0!s} added to {1!s}: {2!s}".format(p.display_prefix,
                 vrf_format(p.vrf), p.node or p.description))
     else:
-        print("Network %s added to %s: %s" % (p.display_prefix,
+        print("Network {0!s} added to {1!s}: {2!s}".format(p.display_prefix,
                 vrf_format(p.vrf), p.description))
 
     if opts.get('add-hosts') is not None:
@@ -856,7 +856,7 @@ def add_prefix_from_pool(arg, opts):
     if 'from-pool' in opts:
         res = Pool.list({ 'name': opts['from-pool'] })
         if len(res) == 0:
-            print("No pool named '%s' found." % opts['from-pool'], file=sys.stderr)
+            print("No pool named '{0!s}' found.".format(opts['from-pool']), file=sys.stderr)
             sys.exit(1)
 
         args['from-pool'] = res[0]
@@ -875,7 +875,7 @@ def add_prefix_from_pool(arg, opts):
             print("ERROR: 'prefix_length' can not be specified for 'dual-stack' assignment", file=sys.stderr)
             sys.exit(1)
     else:
-        print("ERROR: 'family' must be one of: %s" % " ".join(valid_families), file=sys.stderr)
+        print("ERROR: 'family' must be one of: {0!s}".format(" ".join(valid_families)), file=sys.stderr)
         sys.exit(1)
 
     if 'prefix_length' in opts:
@@ -894,14 +894,14 @@ def add_prefix_from_pool(arg, opts):
         # set type to default type of pool unless already set
         if p.type is None:
             if args['from-pool'].default_type is None:
-                print("ERROR: Type not specified and no default-type specified for pool: %s" % opts['from-pool'], file=sys.stderr)
+                print("ERROR: Type not specified and no default-type specified for pool: {0!s}".format(opts['from-pool']), file=sys.stderr)
             p.type = args['from-pool'].default_type
 
         for avp in opts.get('extra-attribute', []):
             try:
                 key, value = avp.split('=', 1)
             except ValueError:
-                print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+                print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
                 return
             p.avps[key] = value
 
@@ -911,14 +911,14 @@ def add_prefix_from_pool(arg, opts):
         try:
             p.save(args)
         except NipapError as exc:
-            print("Could not add prefix to NIPAP: %s" % str(exc), file=sys.stderr)
+            print("Could not add prefix to NIPAP: {0!s}".format(str(exc)), file=sys.stderr)
             sys.exit(1)
 
         if p.type == 'host':
-            print("Host %s added to %s: %s" % (p.display_prefix,
+            print("Host {0!s} added to {1!s}: {2!s}".format(p.display_prefix,
                     vrf_format(p.vrf), p.node or p.description))
         else:
-            print("Network %s added to %s: %s" % (p.display_prefix,
+            print("Network {0!s} added to {1!s}: {2!s}".format(p.display_prefix,
                     vrf_format(p.vrf), p.description))
 
         if opts.get('add-hosts') is not None:
@@ -951,17 +951,17 @@ def add_vrf(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         v.avps[key] = value
 
     try:
         v.save()
     except pynipap.NipapError as exc:
-        print("Could not add VRF to NIPAP: %s" % str(exc), file=sys.stderr)
+        print("Could not add VRF to NIPAP: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Added %s" % (vrf_format(v)))
+    print("Added {0!s}".format((vrf_format(v))))
 
 
 
@@ -988,17 +988,17 @@ def add_pool(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         p.avps[key] = value
 
     try:
         p.save()
     except pynipap.NipapError as exc:
-        print("Could not add pool to NIPAP: %s" % str(exc), file=sys.stderr)
+        print("Could not add pool to NIPAP: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Pool '%s' created." % (p.name))
+    print("Pool '{0!s}' created.".format((p.name)))
 
 
 
@@ -1024,23 +1024,23 @@ def view_vrf(arg, opts, shell_opts):
             'val2': arg }
             )['result'][0]
     except (KeyError, IndexError):
-        print("VRF with [RT: %s] not found." % str(arg), file=sys.stderr)
+        print("VRF with [RT: {0!s}] not found.".format(str(arg)), file=sys.stderr)
         sys.exit(1)
 
     print("-- VRF")
-    print("  %-26s : %d" % ("ID", v.id))
-    print("  %-26s : %s" % ("RT", v.rt))
-    print("  %-26s : %s" % ("Name", v.name))
-    print("  %-26s : %s" % ("Description", v.description))
+    print("  {0:<26!s} : {1:d}".format("ID", v.id))
+    print("  {0:<26!s} : {1!s}".format("RT", v.rt))
+    print("  {0:<26!s} : {1!s}".format("Name", v.name))
+    print("  {0:<26!s} : {1!s}".format("Description", v.description))
 
     print("-- Extra Attributes")
     if v.avps is not None:
         for key in sorted(v.avps, key=lambda s: s.lower()):
-            print("  %-26s : %s" % (key, v.avps[key]))
+            print("  {0:<26!s} : {1!s}".format(key, v.avps[key]))
 
     print("-- Tags")
     for tag_name in sorted(v.tags, key=lambda s: s.lower()):
-        print("  %s" % tag_name)
+        print("  {0!s}".format(tag_name))
     # statistics
     if v.total_addresses_v4 == 0:
         used_percent_v4 = 0
@@ -1051,12 +1051,12 @@ def view_vrf(arg, opts, shell_opts):
     else:
         used_percent_v6 = (float(v.used_addresses_v6)/v.total_addresses_v6)*100
     print("-- Statistics")
-    print("  %-26s : %s" % ("IPv4 prefixes", v.num_prefixes_v4))
-    print("  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 addresses Used / Free",
+    print("  {0:<26!s} : {1!s}".format("IPv4 prefixes", v.num_prefixes_v4))
+    print("  {0:<26!s} : {1:.0f} / {2:.0f} ({3:.2f}% of {4:.0f})".format("IPv4 addresses Used / Free",
             v.used_addresses_v4, v.free_addresses_v4, used_percent_v4,
             v.total_addresses_v4))
-    print("  %-26s : %s" % ("IPv6 prefixes", v.num_prefixes_v6))
-    print("  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 addresses Used / Free",
+    print("  {0:<26!s} : {1!s}".format("IPv6 prefixes", v.num_prefixes_v6))
+    print("  {0:<26!s} : {1:.4e} / {2:.4e} ({3:.2f}% of {4:.4e})".format("IPv6 addresses Used / Free",
             v.used_addresses_v6, v.free_addresses_v6, used_percent_v6,
             v.total_addresses_v6))
 
@@ -1069,7 +1069,7 @@ def view_pool(arg, opts, shell_opts):
     res = Pool.list({ 'name': arg })
 
     if len(res) == 0:
-        print("No pool with name '%s' found." % arg)
+        print("No pool with name '{0!s}' found.".format(arg))
         return
 
     p = res[0]
@@ -1081,21 +1081,21 @@ def view_pool(arg, opts, shell_opts):
         vrf_name = p.vrf.name
 
     print("-- Pool ")
-    print("  %-26s : %d" % ("ID", p.id))
-    print("  %-26s : %s" % ("Name", p.name))
-    print("  %-26s : %s" % ("Description", p.description))
-    print("  %-26s : %s" % ("Default type", p.default_type))
-    print("  %-26s : %s / %s" % ("Implied VRF RT / name", vrf_rt, vrf_name))
-    print("  %-26s : %s / %s" % ("Preflen (v4/v6)", str(p.ipv4_default_prefix_length), str(p.ipv6_default_prefix_length)))
+    print("  {0:<26!s} : {1:d}".format("ID", p.id))
+    print("  {0:<26!s} : {1!s}".format("Name", p.name))
+    print("  {0:<26!s} : {1!s}".format("Description", p.description))
+    print("  {0:<26!s} : {1!s}".format("Default type", p.default_type))
+    print("  {0:<26!s} : {1!s} / {2!s}".format("Implied VRF RT / name", vrf_rt, vrf_name))
+    print("  {0:<26!s} : {1!s} / {2!s}".format("Preflen (v4/v6)", str(p.ipv4_default_prefix_length), str(p.ipv6_default_prefix_length)))
 
     print("-- Extra Attributes")
     if p.avps is not None:
         for key in sorted(p.avps, key=lambda s: s.lower()):
-            print("  %-26s : %s" % (key, p.avps[key]))
+            print("  {0:<26!s} : {1!s}".format(key, p.avps[key]))
 
     print("-- Tags")
     for tag_name in sorted(p.tags, key=lambda s: s.lower()):
-        print("  %s" % tag_name)
+        print("  {0!s}".format(tag_name))
 
     # statistics
     print("-- Statistics")
@@ -1111,7 +1111,7 @@ def view_pool(arg, opts, shell_opts):
         else:
             used_percent_v4 = (float(p.used_prefixes_v4)/p.total_prefixes_v4)*100
 
-        print("  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 prefixes Used / Free",
+        print("  {0:<26!s} : {1:.0f} / {2:.0f} ({3:.2f}% of {4:.0f})".format("IPv4 prefixes Used / Free",
                 p.used_prefixes_v4, p.free_prefixes_v4, used_percent_v4,
                 p.total_prefixes_v4))
 
@@ -1125,7 +1125,7 @@ def view_pool(arg, opts, shell_opts):
             used_percent_v6 = 0
         else:
             used_percent_v6 = (float(p.used_prefixes_v6)/p.total_prefixes_v6)*100
-        print("  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 prefixes Used / Free",
+        print("  {0:<26!s} : {1:.4e} / {2:.4e} ({3:.2f}% of {4:.4e})".format("IPv6 prefixes Used / Free",
                 p.used_prefixes_v6, p.free_prefixes_v6, used_percent_v6,
                 p.total_prefixes_v6))
 
@@ -1141,7 +1141,7 @@ def view_pool(arg, opts, shell_opts):
         else:
             used_percent_v4 = (float(p.used_addresses_v4)/p.total_addresses_v4)*100
 
-        print("  %-26s : %.0f / %.0f (%.2f%% of %.0f)" % ("IPv4 addresses Used / Free",
+        print("  {0:<26!s} : {1:.0f} / {2:.0f} ({3:.2f}% of {4:.0f})".format("IPv4 addresses Used / Free",
                 p.used_addresses_v4, p.free_addresses_v4, used_percent_v4,
                 p.total_addresses_v4))
 
@@ -1155,16 +1155,16 @@ def view_pool(arg, opts, shell_opts):
             used_percent_v6 = 0
         else:
             used_percent_v6 = (float(p.used_addresses_v6)/p.total_addresses_v6)*100
-        print("  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("IPv6 addresses Used / Free",
+        print("  {0:<26!s} : {1:.4e} / {2:.4e} ({3:.2f}% of {4:.4e})".format("IPv6 addresses Used / Free",
                 p.used_addresses_v6, p.free_addresses_v6, used_percent_v6,
                 p.total_addresses_v6))
 
-    print("\n-- Prefixes in pool - v4: %d  v6: %d" % (p.member_prefixes_v4,
+    print("\n-- Prefixes in pool - v4: {0:d}  v6: {1:d}".format(p.member_prefixes_v4,
             p.member_prefixes_v6))
 
     res = Prefix.list({ 'pool_id': p.id})
     for pref in res:
-        print("  %s" % pref.display_prefix)
+        print("  {0!s}".format(pref.display_prefix))
 
 
 
@@ -1199,48 +1199,48 @@ def view_prefix(arg, opts, shell_opts):
         vrf_text = 'any VRF'
         if v.rt != 'all':
             vrf_text = vrf_format(v)
-        print("Address %s not found in %s." % (arg, vrf_text), file=sys.stderr)
+        print("Address {0!s} not found in {1!s}.".format(arg, vrf_text), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
     vrf = p.vrf.rt
 
     print("-- Address ")
-    print("  %-26s : %s" % ("Prefix", p.prefix))
-    print("  %-26s : %s" % ("Display prefix", p.display_prefix))
-    print("  %-26s : %s" % ("Type", p.type))
-    print("  %-26s : %s" % ("Status", p.status))
-    print("  %-26s : IPv%s" % ("Family", p.family))
-    print("  %-26s : %s" % ("VRF", vrf))
-    print("  %-26s : %s" % ("Description", p.description))
-    print("  %-26s : %s" % ("Node", p.node))
-    print("  %-26s : %s" % ("Country", p.country))
-    print("  %-26s : %s" % ("Order", p.order_id))
-    print("  %-26s : %s" % ("Customer", p.customer_id))
-    print("  %-26s : %s" % ("VLAN", p.vlan))
-    print("  %-26s : %s" % ("Alarm priority", p.alarm_priority))
-    print("  %-26s : %s" % ("Monitor", p.monitor))
-    print("  %-26s : %s" % ("Added", p.added))
-    print("  %-26s : %s" % ("Last modified", p.last_modified))
-    print("  %-26s : %s" % ("Expires", p.expires or '-'))
+    print("  {0:<26!s} : {1!s}".format("Prefix", p.prefix))
+    print("  {0:<26!s} : {1!s}".format("Display prefix", p.display_prefix))
+    print("  {0:<26!s} : {1!s}".format("Type", p.type))
+    print("  {0:<26!s} : {1!s}".format("Status", p.status))
+    print("  {0:<26!s} : IPv{1!s}".format("Family", p.family))
+    print("  {0:<26!s} : {1!s}".format("VRF", vrf))
+    print("  {0:<26!s} : {1!s}".format("Description", p.description))
+    print("  {0:<26!s} : {1!s}".format("Node", p.node))
+    print("  {0:<26!s} : {1!s}".format("Country", p.country))
+    print("  {0:<26!s} : {1!s}".format("Order", p.order_id))
+    print("  {0:<26!s} : {1!s}".format("Customer", p.customer_id))
+    print("  {0:<26!s} : {1!s}".format("VLAN", p.vlan))
+    print("  {0:<26!s} : {1!s}".format("Alarm priority", p.alarm_priority))
+    print("  {0:<26!s} : {1!s}".format("Monitor", p.monitor))
+    print("  {0:<26!s} : {1!s}".format("Added", p.added))
+    print("  {0:<26!s} : {1!s}".format("Last modified", p.last_modified))
+    print("  {0:<26!s} : {1!s}".format("Expires", p.expires or '-'))
     if p.family == 4:
-        print("  %-26s : %s / %s (%.2f%% of %s)" % ("Addresses Used / Free", p.used_addresses,
+        print("  {0:<26!s} : {1!s} / {2!s} ({3:.2f}% of {4!s})".format("Addresses Used / Free", p.used_addresses,
                 p.free_addresses, (float(p.used_addresses)/p.total_addresses)*100,
                 p.total_addresses))
     else:
-        print("  %-26s : %.4e / %.4e (%.2f%% of %.4e)" % ("Addresses Used / Free", p.used_addresses,
+        print("  {0:<26!s} : {1:.4e} / {2:.4e} ({3:.2f}% of {4:.4e})".format("Addresses Used / Free", p.used_addresses,
                 p.free_addresses, (float(p.used_addresses)/p.total_addresses)*100,
                 p.total_addresses))
     print("-- Extra Attributes")
     if p.avps is not None:
         for key in sorted(p.avps, key=lambda s: s.lower()):
-            print("  %-26s : %s" % (key, p.avps[key]))
+            print("  {0:<26!s} : {1!s}".format(key, p.avps[key]))
     print("-- Tags")
     for tag_name in sorted(p.tags, key=lambda s: s.lower()):
-        print("  %s" % tag_name)
+        print("  {0!s}".format(tag_name))
     print("-- Inherited Tags")
     for tag_name in sorted(p.inherited_tags, key=lambda s: s.lower()):
-        print("  %s" % tag_name)
+        print("  {0!s}".format(tag_name))
     print("-- Comment")
     print(p.comment or '')
 
@@ -1258,15 +1258,15 @@ def remove_vrf(arg, opts, shell_opts):
 
     res = VRF.list({ 'rt': arg })
     if len(res) < 1:
-        print("VRF with [RT: %s] not found." % arg, file=sys.stderr)
+        print("VRF with [RT: {0!s}] not found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     v = res[0]
 
     if not remove_confirmed:
-        print("RT: %s\nName: %s\nDescription: %s" % (v.rt, v.name, v.description))
+        print("RT: {0!s}\nName: {1!s}\nDescription: {2!s}".format(v.rt, v.name, v.description))
         print("\nWARNING: THIS WILL REMOVE THE VRF INCLUDING ALL ITS ADDRESSES")
-        res = input("Do you really want to remove %s? [y/N]: " % vrf_format(v))
+        res = input("Do you really want to remove {0!s}? [y/N]: ".format(vrf_format(v)))
 
         if res == 'y':
             remove_confirmed = True
@@ -1275,7 +1275,7 @@ def remove_vrf(arg, opts, shell_opts):
 
     if remove_confirmed:
         v.remove()
-        print("%s removed." % vrf_format(v))
+        print("{0!s} removed.".format(vrf_format(v)))
 
 
 
@@ -1287,13 +1287,13 @@ def remove_pool(arg, opts, shell_opts):
 
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
 
     if not remove_confirmed:
-        res = input("Do you really want to remove the pool '%s'? [y/N]: " % p.name)
+        res = input("Do you really want to remove the pool '{0!s}'? [y/N]: ".format(p.name))
 
         if res == 'y':
             remove_confirmed = True
@@ -1302,7 +1302,7 @@ def remove_pool(arg, opts, shell_opts):
 
     if remove_confirmed:
         p.remove()
-        print("Pool '%s' removed." % p.name)
+        print("Pool '{0!s}' removed.".format(p.name))
 
 
 def remove_prefix(arg, opts, shell_opts):
@@ -1328,7 +1328,7 @@ def remove_prefix(arg, opts, shell_opts):
         vrf_text = 'any VRF'
         if v.rt != 'all':
             vrf_text = vrf_format(v)
-        print("Prefix %s not found in %s." % (arg, vrf_text), file=sys.stderr)
+        print("Prefix {0!s} not found in {1!s}.".format(arg, vrf_text), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
@@ -1366,36 +1366,36 @@ def remove_prefix(arg, opts, shell_opts):
         # delete instead
         if p.type == 'assignment':
             if len(pres['result']) > 1:
-                print("WARNING: %s in %s contains %s hosts." % (p.prefix, vrf_format(p.vrf), len(pres['result'])))
-                res = input("Would you like to recursively delete %s and all hosts? [y/N]: " % (p.prefix))
+                print("WARNING: {0!s} in {1!s} contains {2!s} hosts.".format(p.prefix, vrf_format(p.vrf), len(pres['result'])))
+                res = input("Would you like to recursively delete {0!s} and all hosts? [y/N]: ".format((p.prefix)))
                 if res.lower() in [ 'y', 'yes' ]:
                     recursive = True
                 else:
-                    print("ERROR: Removal of assignment containing hosts is prohibited. Aborting removal of %s in %s." % (p.prefix, vrf_format(p.vrf)), file=sys.stderr)
+                    print("ERROR: Removal of assignment containing hosts is prohibited. Aborting removal of {0!s} in {1!s}.".format(p.prefix, vrf_format(p.vrf)), file=sys.stderr)
                     sys.exit(1)
 
         if recursive is True:
             if len(pres['result']) <= 1:
-                res = input("Do you really want to remove the prefix %s in %s? [y/N]: " % (p.prefix, vrf_format(p.vrf)))
+                res = input("Do you really want to remove the prefix {0!s} in {1!s}? [y/N]: ".format(p.prefix, vrf_format(p.vrf)))
 
                 if res.lower() in [ 'y', 'yes' ]:
                     remove_confirmed = True
 
             else:
-                print("Recursively deleting %s in %s will delete the following prefixes:" % (p.prefix, vrf_format(p.vrf)))
+                print("Recursively deleting {0!s} in {1!s} will delete the following prefixes:".format(p.prefix, vrf_format(p.vrf)))
 
                 # Iterate prefixes to print a few of them and check the prefixes'
                 # authoritative source
                 i = 0
                 for rp in pres['result']:
                     if i <= 10:
-                        print("%-29s %-2s %-19s %-14s %-14s %-40s" % ("".join("  " for i in
+                        print("{0:<29!s} {1:<2!s} {2:<19!s} {3:<14!s} {4:<14!s} {5:<40!s}".format("".join("  " for i in
                             range(rp.indent)) + rp.display_prefix,
                             rp.type[0].upper(), rp.node, rp.order_id,
                             rp.customer_id, rp.description))
 
                     if i == 10:
-                        print(".. and %s other prefixes" % (len(pres['result']) - 10))
+                        print(".. and {0!s} other prefixes".format((len(pres['result']) - 10)))
 
                     if rp.authoritative_source != 'nipap':
                         auth_src.add(rp.authoritative_source)
@@ -1404,7 +1404,7 @@ def remove_prefix(arg, opts, shell_opts):
 
                 if len(auth_src) == 0:
                     # Simple case; all prefixes were added from NIPAP
-                    res = input("Do you really want to recursively remove %s prefixes in %s? [y/N]: " % (len(pres['result']),
+                    res = input("Do you really want to recursively remove {0!s} prefixes in {1!s}? [y/N]: ".format(len(pres['result']),
                                 vrf_format(vrf)))
 
                     if res.lower() in [ 'y', 'yes' ]:
@@ -1417,11 +1417,11 @@ def remove_prefix(arg, opts, shell_opts):
 
                     # format prompt depending on how many different sources we have
                     if len(auth_src) == 1:
-                        systems = "'%s'" % auth_src[0]
+                        systems = "'{0!s}'".format(auth_src[0])
                         prompt = "Enter the name of the managing system to continue or anything else to abort: "
 
                     else:
-                        systems = ", ".join("'%s'" % x for x in auth_src[1:]) + " and '%s'" % auth_src[0]
+                        systems = ", ".join("'{0!s}'".format(x) for x in auth_src[1:]) + " and '{0!s}'".format(auth_src[0])
                         plural = "s"
                         prompt = "Enter the name of the last managing system to continue or anything else to abort: "
 
@@ -1454,17 +1454,17 @@ def remove_prefix(arg, opts, shell_opts):
                     sys.exit(1)
 
             else:
-                res = input("Do you really want to remove the prefix %s in %s? [y/N]: " % (p.prefix, vrf_format(p.vrf)))
+                res = input("Do you really want to remove the prefix {0!s} in {1!s}? [y/N]: ".format(p.prefix, vrf_format(p.vrf)))
                 if res.lower() in [ 'y', 'yes' ]:
                     remove_confirmed = True
 
     if remove_confirmed is True:
         p.remove(recursive = recursive)
         if recursive is True:
-            print("Prefix %s and %s other prefixes in %s removed." % (p.prefix,
+            print("Prefix {0!s} and {1!s} other prefixes in {2!s} removed.".format(p.prefix,
                     (len(pres['result']) - 1), vrf_format(p.vrf)))
         else:
-            print("Prefix %s in %s removed." % (p.prefix, vrf_format(p.vrf)))
+            print("Prefix {0!s} in {1!s} removed.".format(p.prefix, vrf_format(p.vrf)))
 
     else:
         print("Operation canceled.")
@@ -1480,7 +1480,7 @@ def modify_vrf(arg, opts, shell_opts):
 
     res = VRF.list({ 'rt': arg })
     if len(res) < 1:
-        print("VRF with [RT: %s] not found." % arg, file=sys.stderr)
+        print("VRF with [RT: {0!s}] not found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     v = res[0]
@@ -1503,13 +1503,13 @@ def modify_vrf(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         v.avps[key] = value
 
     v.save()
 
-    print("%s saved." % vrf_format(v))
+    print("{0!s} saved.".format(vrf_format(v)))
 
 
 
@@ -1519,7 +1519,7 @@ def modify_pool(arg, opts, shell_opts):
 
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
@@ -1546,14 +1546,14 @@ def modify_pool(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         p.avps[key] = value
 
 
     p.save()
 
-    print("Pool '%s' saved." % p.name)
+    print("Pool '{0!s}' saved.".format(p.name))
 
 
 
@@ -1561,11 +1561,11 @@ def grow_pool(arg, opts, shell_opts):
     """ Expand a pool with the ranges set in opts
     """
     if not pool:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     if not 'add' in opts:
-        print("Please supply a prefix to add to pool '%s'" % pool.name, file=sys.stderr)
+        print("Please supply a prefix to add to pool '{0!s}'".format(pool.name), file=sys.stderr)
         sys.exit(1)
 
     # Figure out VRF.
@@ -1585,18 +1585,18 @@ def grow_pool(arg, opts, shell_opts):
     res = Prefix.list(q)
 
     if len(res) == 0:
-        print("No prefix found matching %s in %s." % (opts['add'], vrf_format(v)), file=sys.stderr)
+        print("No prefix found matching {0!s} in {1!s}.".format(opts['add'], vrf_format(v)), file=sys.stderr)
         sys.exit(1)
     elif res[0].pool:
         if res[0].pool == pool:
-            print("Prefix %s in %s is already assigned to that pool." % (opts['add'], vrf_format(v)), file=sys.stderr)
+            print("Prefix {0!s} in {1!s} is already assigned to that pool.".format(opts['add'], vrf_format(v)), file=sys.stderr)
         else:
-            print("Prefix %s in %s is already assigned to a different pool ('%s')." % (opts['add'], vrf_format(v), res[0].pool.name), file=sys.stderr)
+            print("Prefix {0!s} in {1!s} is already assigned to a different pool ('{2!s}').".format(opts['add'], vrf_format(v), res[0].pool.name), file=sys.stderr)
         sys.exit(1)
 
     res[0].pool = pool
     res[0].save()
-    print("Prefix %s in %s added to pool '%s'." % (res[0].prefix, vrf_format(v), pool.name))
+    print("Prefix {0!s} in {1!s} added to pool '{2!s}'.".format(res[0].prefix, vrf_format(v), pool.name))
 
 
 
@@ -1604,25 +1604,25 @@ def shrink_pool(arg, opts, shell_opts):
     """ Shrink a pool by removing the ranges in opts from it
     """
     if not pool:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     if 'remove' in opts:
         res = Prefix.list({'prefix': opts['remove'], 'pool_id': pool.id})
 
         if len(res) == 0:
-            print("Pool '%s' does not contain %s." % (pool.name,
+            print("Pool '{0!s}' does not contain {1!s}.".format(pool.name,
                 opts['remove']), file=sys.stderr)
             sys.exit(1)
 
         res[0].pool = None
         res[0].save()
-        print("Prefix %s removed from pool '%s'." % (res[0].prefix, pool.name))
+        print("Prefix {0!s} removed from pool '{1!s}'.".format(res[0].prefix, pool.name))
     else:
-        print("Please supply a prefix to add or remove to '%s':" % (
-            pool.name), file=sys.stderr)
+        print("Please supply a prefix to add or remove to '{0!s}':".format((
+            pool.name)), file=sys.stderr)
         for pref in Prefix.list({'pool_id': pool.id}):
-            print("  %s" % pref.prefix)
+            print("  {0!s}".format(pref.prefix))
 
 
 
@@ -1638,7 +1638,7 @@ def modify_prefix(arg, opts, shell_opts):
 
     res = Prefix.list(spec)
     if len(res) == 0:
-        print("Prefix %s not found in %s." % (arg, vrf_format(v)), file=sys.stderr)
+        print("Prefix {0!s} not found in {1!s}.".format(arg, vrf_format(v)), file=sys.stderr)
         return
 
     p = res[0]
@@ -1681,7 +1681,7 @@ def modify_prefix(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             return
         p.avps[key] = value
 
@@ -1689,8 +1689,7 @@ def modify_prefix(arg, opts, shell_opts):
     # Promt user if prefix has authoritative source != nipap
     if not modify_confirmed and p.authoritative_source.lower() != 'nipap':
 
-        res = input("Prefix %s in %s is managed by system '%s'. Are you sure you want to modify it? [y/n]: " %
-            (p.prefix, vrf_format(p.vrf), p.authoritative_source))
+        res = input("Prefix {0!s} in {1!s} is managed by system '{2!s}'. Are you sure you want to modify it? [y/n]: ".format(p.prefix, vrf_format(p.vrf), p.authoritative_source))
 
         # If the user declines, short-circuit...
         if res.lower() not in [ 'y', 'yes' ]:
@@ -1700,10 +1699,10 @@ def modify_prefix(arg, opts, shell_opts):
     try:
         p.save()
     except NipapError as exc:
-        print("Could not save prefix changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save prefix changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Prefix %s in %s saved." % (p.display_prefix, vrf_format(p.vrf)))
+    print("Prefix {0!s} in {1!s} saved.".format(p.display_prefix, vrf_format(p.vrf)))
 
 
 
@@ -1717,7 +1716,7 @@ def prefix_attr_add(arg, opts, shell_opts):
 
     res = Prefix.list(spec)
     if len(res) == 0:
-        print("Prefix %s not found in %s." % (arg, vrf_format(v)), file=sys.stderr)
+        print("Prefix {0!s} not found in {1!s}.".format(arg, vrf_format(v)), file=sys.stderr)
         return
 
     p = res[0]
@@ -1726,11 +1725,11 @@ def prefix_attr_add(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             sys.exit(1)
 
         if key in p.avps:
-            print("Unable to add extra-attribute: '%s' already exists." % key, file=sys.stderr)
+            print("Unable to add extra-attribute: '{0!s}' already exists.".format(key), file=sys.stderr)
             sys.exit(1)
 
         p.avps[key] = value
@@ -1738,10 +1737,10 @@ def prefix_attr_add(arg, opts, shell_opts):
     try:
         p.save()
     except NipapError as exc:
-        print("Could not save prefix changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save prefix changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Prefix %s in %s saved." % (p.display_prefix, vrf_format(p.vrf)))
+    print("Prefix {0!s} in {1!s} saved.".format(p.display_prefix, vrf_format(p.vrf)))
 
 
 
@@ -1755,14 +1754,14 @@ def prefix_attr_remove(arg, opts, shell_opts):
 
     res = Prefix.list(spec)
     if len(res) == 0:
-        print("Prefix %s not found in %s." % (arg, vrf_format(v)), file=sys.stderr)
+        print("Prefix {0!s} not found in {1!s}.".format(arg, vrf_format(v)), file=sys.stderr)
         return
 
     p = res[0]
 
     for key in opts.get('extra-attribute', []):
         if key not in p.avps:
-            print("Unable to remove extra-attribute: '%s' does not exist." % key, file=sys.stderr)
+            print("Unable to remove extra-attribute: '{0!s}' does not exist.".format(key), file=sys.stderr)
             sys.exit(1)
 
         del p.avps[key]
@@ -1770,10 +1769,10 @@ def prefix_attr_remove(arg, opts, shell_opts):
     try:
         p.save()
     except NipapError as exc:
-        print("Could not save prefix changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save prefix changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Prefix %s in %s saved." % (p.display_prefix, vrf_format(p.vrf)))
+    print("Prefix {0!s} in {1!s} saved.".format(p.display_prefix, vrf_format(p.vrf)))
 
 
 
@@ -1796,18 +1795,18 @@ def vrf_attr_add(arg, opts, shell_opts):
             'val2': arg }
             )['result'][0]
     except (KeyError, IndexError):
-        print("VRF with [RT: %s] not found." % str(arg), file=sys.stderr)
+        print("VRF with [RT: {0!s}] not found.".format(str(arg)), file=sys.stderr)
         sys.exit(1)
 
     for avp in opts.get('extra-attribute', []):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             sys.exit(1)
 
         if key in v.avps:
-            print("Unable to add extra-attribute: '%s' already exists." % key, file=sys.stderr)
+            print("Unable to add extra-attribute: '{0!s}' already exists.".format(key), file=sys.stderr)
             sys.exit(1)
 
         v.avps[key] = value
@@ -1815,10 +1814,10 @@ def vrf_attr_add(arg, opts, shell_opts):
     try:
         v.save()
     except NipapError as exc:
-        print("Could not save VRF changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save VRF changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("%s saved." % vrf_format(v))
+    print("{0!s} saved.".format(vrf_format(v)))
 
 
 
@@ -1841,12 +1840,12 @@ def vrf_attr_remove(arg, opts, shell_opts):
             'val2': arg }
             )['result'][0]
     except (KeyError, IndexError):
-        print("VRF with [RT: %s] not found." % str(arg), file=sys.stderr)
+        print("VRF with [RT: {0!s}] not found.".format(str(arg)), file=sys.stderr)
         sys.exit(1)
 
     for key in opts.get('extra-attribute', []):
         if key not in v.avps:
-            print("Unable to remove extra-attribute: '%s' does not exist." % key, file=sys.stderr)
+            print("Unable to remove extra-attribute: '{0!s}' does not exist.".format(key), file=sys.stderr)
             sys.exit(1)
 
         del v.avps[key]
@@ -1854,10 +1853,10 @@ def vrf_attr_remove(arg, opts, shell_opts):
     try:
         v.save()
     except NipapError as exc:
-        print("Could not save VRF changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save VRF changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("%s saved." % vrf_format(v))
+    print("{0!s} saved.".format(vrf_format(v)))
 
 
 
@@ -1867,7 +1866,7 @@ def pool_attr_add(arg, opts, shell_opts):
 
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
@@ -1876,11 +1875,11 @@ def pool_attr_add(arg, opts, shell_opts):
         try:
             key, value = avp.split('=', 1)
         except ValueError:
-            print("ERROR: Incorrect extra-attribute: %s. Accepted form: 'key=value'\n" % avp, file=sys.stderr)
+            print("ERROR: Incorrect extra-attribute: {0!s}. Accepted form: 'key=value'\n".format(avp), file=sys.stderr)
             sys.exit(1)
 
         if key in p.avps:
-            print("Unable to add extra-attribute: '%s' already exists." % key, file=sys.stderr)
+            print("Unable to add extra-attribute: '{0!s}' already exists.".format(key), file=sys.stderr)
             sys.exit(1)
 
         p.avps[key] = value
@@ -1888,10 +1887,10 @@ def pool_attr_add(arg, opts, shell_opts):
     try:
         p.save()
     except NipapError as exc:
-        print("Could not save pool changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save pool changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Pool '%s' saved." % p.name)
+    print("Pool '{0!s}' saved.".format(p.name))
 
 
 
@@ -1901,14 +1900,14 @@ def pool_attr_remove(arg, opts, shell_opts):
 
     res = Pool.list({ 'name': arg })
     if len(res) < 1:
-        print("No pool with name '%s' found." % arg, file=sys.stderr)
+        print("No pool with name '{0!s}' found.".format(arg), file=sys.stderr)
         sys.exit(1)
 
     p = res[0]
 
     for key in opts.get('extra-attribute', []):
         if key not in p.avps:
-            print("Unable to remove extra-attribute: '%s' does not exist." % key, file=sys.stderr)
+            print("Unable to remove extra-attribute: '{0!s}' does not exist.".format(key), file=sys.stderr)
             sys.exit(1)
 
         del p.avps[key]
@@ -1916,10 +1915,10 @@ def pool_attr_remove(arg, opts, shell_opts):
     try:
         p.save()
     except NipapError as exc:
-        print("Could not save pool changes: %s" % str(exc), file=sys.stderr)
+        print("Could not save pool changes: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
-    print("Pool '%s' saved." % p.name)
+    print("Pool '{0!s}' saved.".format(p.name))
 
 
 
@@ -2076,7 +2075,7 @@ def complete_vrf(arg):
 
     search_string = ''
     if arg is not None:
-        search_string = '^%s' % arg
+        search_string = '^{0!s}'.format(arg)
 
     res = VRF.search({
         'operator': 'regex_match',
@@ -2105,7 +2104,7 @@ def complete_vrf_virtual(arg):
 
     search_string = ''
     if arg is not None:
-        search_string = '^%s' % arg
+        search_string = '^{0!s}'.format(arg)
 
     if re.match(search_string, 'all'):
         ret.append('all')
@@ -2167,7 +2166,7 @@ cmds = {
                             'type': 'option',
                             'argument': {
                                 'type': 'value',
-                                'description': 'Prefix status: %s' % ' | '.join(valid_prefix_status),
+                                'description': 'Prefix status: {0!s}'.format(' | '.join(valid_prefix_status)),
                                 'content_type': str,
                                 'complete': complete_prefix_status,
                             }
@@ -2401,7 +2400,7 @@ cmds = {
                                     'type': 'option',
                                     'argument': {
                                         'type': 'value',
-                                        'description': 'Prefix status: %s' % ' | '.join(valid_prefix_status),
+                                        'description': 'Prefix status: {0!s}'.format(' | '.join(valid_prefix_status)),
                                         'content_type': str,
                                         'complete': complete_prefix_status,
                                     }
@@ -3007,18 +3006,18 @@ if __name__ == '__main__':
     try:
         cmd = Command(cmds, sys.argv[1::])
     except ValueError as exc:
-        print("Error: %s" % str(exc), file=sys.stderr)
+        print("Error: {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 
     # execute command
     if cmd.exe is None:
         print("Incomplete command specified")
-        print("valid completions: %s" % " ".join(cmd.next_values()))
+        print("valid completions: {0!s}".format(" ".join(cmd.next_values())))
         sys.exit(1)
 
     try:
         cmd.exe(cmd.arg, cmd.exe_options)
     except NipapError as exc:
-        print("Command failed:\n  %s" % str(exc), file=sys.stderr)
+        print("Command failed:\n  {0!s}".format(str(exc)), file=sys.stderr)
         sys.exit(1)
 

--- a/nipap-www/nipapwww/controllers/error.py
+++ b/nipap-www/nipapwww/controllers/error.py
@@ -42,13 +42,13 @@ class ErrorController(BaseController):
         </div>
         <div class="content_outer">
             <div class="content_inner">
-                <p>%s</p>
+                <p>{0!s}</p>
                 <p>Relevant information has been forwarded to the system administrator.</p>
             </div>
 			<div style="height: 500px;"> &nbsp; </div>
         </div>
     </body>
-</html>""" % content
+</html>""".format(content)
 
         # If the error was raised from the XhrController, return HTML-less response
         if type(request.environ['pylons.original_request'].environ.get('pylons.controller')) == XhrController:
@@ -69,5 +69,5 @@ class ErrorController(BaseController):
         at the specified path
         """
         request = self._py_object.request
-        request.environ['PATH_INFO'] = '/%s' % path
+        request.environ['PATH_INFO'] = '/{0!s}'.format(path)
         return PkgResourcesParser('pylons', 'pylons')(request.environ, self.start_response)

--- a/nipap-www/nipapwww/controllers/xhr.py
+++ b/nipap-www/nipapwww/controllers/xhr.py
@@ -556,7 +556,7 @@ class XhrController(BaseController):
                 else:
                     p.vrf = VRF.get(int(request.json['vrf']))
             except ValueError:
-                return json.dumps({'error': 1, 'message': "Invalid VRF ID '%s'" % request.json['vrf']})
+                return json.dumps({'error': 1, 'message': "Invalid VRF ID '{0!s}'".format(request.json['vrf'])})
             except NipapError, e:
                 return json.dumps({'error': 1, 'message': e.args, 'type': type(e).__name__})
 
@@ -684,7 +684,7 @@ class XhrController(BaseController):
                     else:
                         p.vrf = VRF.get(int(request.json['vrf']))
                 except ValueError:
-                    return json.dumps({'error': 1, 'message': "Invalid VRF ID '%s'" % request.json['vrf']})
+                    return json.dumps({'error': 1, 'message': "Invalid VRF ID '{0!s}'".format(request.json['vrf'])})
                 except NipapError, e:
                     return json.dumps({'error': 1, 'message': e.args, 'type': type(e).__name__})
 

--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -116,7 +116,7 @@ class AuthFactory:
                 auth_backend = section_components[1]
                 self._backends[auth_backend] = eval(self._config.get(section, 'type'))
 
-        self._logger.debug("Registered auth backends %s" % str(self._backends))
+        self._logger.debug("Registered auth backends {0!s}".format(str(self._backends)))
 
 
 
@@ -168,7 +168,7 @@ class AuthFactory:
         backend = ""
         if len(user_authbackend) == 1:
             backend = self._config.get('auth', 'default_backend')
-            self._logger.debug("Using default auth backend %s" % backend)
+            self._logger.debug("Using default auth backend {0!s}".format(backend))
         else:
             backend = user_authbackend[1]
     
@@ -176,15 +176,15 @@ class AuthFactory:
         auth_str = ( str(username) + str(password) + str(authoritative_source)
             + str(auth_options) )
         if auth_str in self._auth_cache:
-            self._logger.debug('found cached auth object for user %s' % username)
+            self._logger.debug('found cached auth object for user {0!s}'.format(username))
             return self._auth_cache[auth_str]['auth_object']
 
         # Create auth object
         try:
             auth = self._backends[backend](backend, user_authbackend[0], password, authoritative_source, auth_options)
         except KeyError:
-            raise AuthError("Invalid auth backend '%s' specified" %
-                str(backend))
+            raise AuthError("Invalid auth backend '{0!s}' specified".format(
+                str(backend)))
 
         # save auth object to cache
         self._auth_cache[auth_str] = {
@@ -374,7 +374,7 @@ class LdapAuth(BaseAuth):
         except (ldap.INVALID_CREDENTIALS, ldap.INVALID_DN_SYNTAX,
                 ldap.UNWILLING_TO_PERFORM) as exc:
             # Auth failed
-            self._logger.debug('erroneous password for user %s' % self.username)
+            self._logger.debug('erroneous password for user {0!s}'.format(self.username))
             self._authenticated = False
             return self._authenticated
 
@@ -427,7 +427,7 @@ class LdapAuth(BaseAuth):
 
         self._authenticated = True
 
-        self._logger.debug('successfully authenticated as %s, username %s, full_name %s, readonly %s' % (self.authenticated_as, self.username, self.full_name, str(self.readonly)))
+        self._logger.debug('successfully authenticated as {0!s}, username {1!s}, full_name {2!s}, readonly {3!s}'.format(self.authenticated_as, self.username, self.full_name, str(self.readonly)))
         return self._authenticated
 
 
@@ -477,7 +477,7 @@ class SqliteAuth(BaseAuth):
             self._db_curs = self._db_conn.cursor()
 
         except sqlite3.Error as exc:
-            self._logger.error('Could not open user database: %s' % str(exc))
+            self._logger.error('Could not open user database: {0!s}'.format(str(exc)))
             raise AuthError(str(exc))
 
 
@@ -496,7 +496,7 @@ class SqliteAuth(BaseAuth):
 
         for column in ('username', 'pwd_salt', 'pwd_hash', 'full_name',
                 'trusted', 'readonly'):
-            sql = "SELECT %s FROM user" % column
+            sql = "SELECT {0!s} FROM user".format(column)
             try:
                 self._db_curs.execute(sql)
             except:
@@ -554,19 +554,19 @@ class SqliteAuth(BaseAuth):
         if self._authenticated is not None:
             return self._authenticated
 
-        self._logger.debug('Trying to authenticate as user \'%s\'' % self.username)
+        self._logger.debug('Trying to authenticate as user \'{0!s}\''.format(self.username))
 
         user = self.get_user(self.username)
         # Was user found?
         if user is None:
-            self._logger.debug('unknown user %s' % self.username)
+            self._logger.debug('unknown user {0!s}'.format(self.username))
             self._authenticated = False
             return self._authenticated
 
         # verify password
         if self._gen_hash(self.password, user['pwd_salt']) != user['pwd_hash']:
             # Auth failed
-            self._logger.debug('erroneous password for user %s' % self.username)
+            self._logger.debug('erroneous password for user {0!s}'.format(self.username))
             self._authenticated = False
             return self._authenticated
 
@@ -595,7 +595,7 @@ class SqliteAuth(BaseAuth):
         else:
             self.full_name = user['full_name']
 
-        self._logger.debug('successfully authenticated as %s, username %s, full_name %s, readonly %s' % (self.authenticated_as, self.username, self.full_name, str(self.readonly)))
+        self._logger.debug('successfully authenticated as {0!s}, username {1!s}, full_name {2!s}, readonly {3!s}'.format(self.authenticated_as, self.username, self.full_name, str(self.readonly)))
         return self._authenticated
 
 
@@ -678,7 +678,7 @@ class SqliteAuth(BaseAuth):
             del(data['password'])
 
         sql = "UPDATE user SET "
-        sql += ', '.join("%s = ?" % k for k in sorted(data))
+        sql += ', '.join("{0!s} = ?".format(k) for k in sorted(data))
         sql += " WHERE username = ?"
 
         vals = []

--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -566,8 +566,8 @@ def requires_rw(f):
         auth = args[1]
         if auth.readonly:
             logger = logging.getLogger()
-            logger.info("read-only user '%s' is not authorized to run function '%s'" % (auth.username, f.__name__))
-            raise authlib.AuthorizationFailed("read-only user '%s' is not authorized to run function '%s'" % (auth.username, f.__name__))
+            logger.info("read-only user '{0!s}' is not authorized to run function '{1!s}'".format(auth.username, f.__name__))
+            raise authlib.AuthorizationFailed("read-only user '{0!s}' is not authorized to run function '{1!s}'".format(auth.username, f.__name__))
         return f(*args, **kwargs)
 
     return decorated
@@ -777,7 +777,7 @@ class Nipap:
                 psycopg2.extras.register_hstore(self._con_pg, globally=True, unicode=True)
             except psycopg2.Error as exc:
                 if re.search("database.*does not exist", str(exc)):
-                    raise NipapDatabaseNonExistentError("Database '%s' does not exist" % db_args['database'])
+                    raise NipapDatabaseNonExistentError("Database '{0!s}' does not exist".format(db_args['database']))
                 # no hstore extension, assume empty db (it wouldn't work
                 # otherwise) and do auto upgrade?
                 if re.search("hstore type not found in the database", str(exc)):
@@ -787,10 +787,10 @@ class Nipap:
                         continue
                     raise NipapDatabaseMissingExtensionError("hstore extension not found in the database")
 
-                self._logger.error("pgsql: %s" % exc)
+                self._logger.error("pgsql: {0!s}".format(exc))
                 raise NipapError("Backend unable to connect to database")
             except psycopg2.Warning as warn:
-                self._logger.warning('pgsql: %s' % warn)
+                self._logger.warning('pgsql: {0!s}'.format(warn))
 
             # check db version
             try:
@@ -811,7 +811,7 @@ class Nipap:
                 if self._auto_upgrade_db:
                     self._db_upgrade()
                     continue
-                raise NipapDatabaseWrongVersionError("NIPAP PostgreSQL database is outdated. Schema version %s is required to run but you are using %s" % (nipap.__db_version__, current_db_version))
+                raise NipapDatabaseWrongVersionError("NIPAP PostgreSQL database is outdated. Schema version {0!s} is required to run but you are using {1!s}".format(nipap.__db_version__, current_db_version))
 
             # if we reach this we should be fine and done
             break
@@ -856,7 +856,7 @@ class Nipap:
             if code == '1200':
                 raise NipapValueError(text)
 
-            estr = "Internal database error: %s" % exc
+            estr = "Internal database error: {0!s}".format(exc)
             self._logger.error(estr)
             raise NipapError(str(exc))
 
@@ -905,12 +905,12 @@ class Nipap:
             m = re.search('invalid cidr value: "([^"]+)"', exc.pgerror)
             if m is not None:
                 strict_prefix = str(IPy.IP(m.group(1), make_net = True))
-                estr = "Invalid prefix (%s); bits set to right of mask. Network address for current mask: %s" % (m.group(1), strict_prefix)
+                estr = "Invalid prefix ({0!s}); bits set to right of mask. Network address for current mask: {1!s}".format(m.group(1), strict_prefix)
                 raise NipapValueError(estr)
 
             m = re.search('invalid input syntax for type (cidr|inet): "([^"]+)"', exc.pgerror)
             if m is not None:
-                estr = "Invalid syntax for prefix (%s)" % m.group(2)
+                estr = "Invalid syntax for prefix ({0!s})".format(m.group(2))
                 raise NipapValueError(estr)
 
             raise NipapValueError(str(exc))
@@ -921,7 +921,7 @@ class Nipap:
             except psycopg2.Error:
                 pass
 
-            estr = "Unable to execute query: %s" % exc
+            estr = "Unable to execute query: {0!s}".format(exc)
             self._logger.error(estr)
 
             # abort if we've already tried to reconnect
@@ -1006,10 +1006,10 @@ class Nipap:
 
         for a in req_attr:
             if not a in attr:
-                raise NipapMissingInputError("missing attribute %s" % a)
+                raise NipapMissingInputError("missing attribute {0!s}".format(a))
         for a in attr:
             if a not in allowed_attr:
-                raise NipapExtraneousInputError("extraneous attribute %s" % a)
+                raise NipapExtraneousInputError("extraneous attribute {0!s}".format(a))
 
         if 'avps' in attr and '' in attr['avps']:
             raise NipapValueError('AVP with empty name is not allowed')
@@ -1096,10 +1096,10 @@ class Nipap:
         """
 
         dbname = self._cfg.get('nipapd', 'db_name')
-        self._execute("SELECT description FROM pg_shdescription JOIN pg_database ON objoid = pg_database.oid WHERE datname = '%s'" % dbname)
+        self._execute("SELECT description FROM pg_shdescription JOIN pg_database ON objoid = pg_database.oid WHERE datname = '{0!s}'".format(dbname))
         comment = self._curs_pg.fetchone()
         if comment is None:
-            raise NipapDatabaseNoVersionError("Could not find comment of psql database %s" % dbname)
+            raise NipapDatabaseNoVersionError("Could not find comment of psql database {0!s}".format(dbname))
 
         db_version = None
         m = re.match('NIPAP database - schema version: ([0-9]+)', comment[0])
@@ -1159,7 +1159,7 @@ class Nipap:
         allowed_values = ['id', 'name', 'rt']
         for a in spec:
             if a not in allowed_values:
-                raise NipapExtraneousInputError("extraneous specification key %s" % a)
+                raise NipapExtraneousInputError("extraneous specification key {0!s}".format(a))
 
         if 'id' in spec:
             if type(spec['id']) not in (int, long):
@@ -1202,9 +1202,9 @@ class Nipap:
             sub_where1, opt1 = self._expand_vrf_query(query['val1'], table_name)
             sub_where2, opt2 = self._expand_vrf_query(query['val2'], table_name)
             try:
-                where += str(" (%s %s %s) " % (sub_where1, _operation_map[query['operator']], sub_where2) )
+                where += str(" ({0!s} {1!s} {2!s}) ".format(sub_where1, _operation_map[query['operator']], sub_where2) )
             except KeyError:
-                raise NipapNoSuchOperatorError("No such operator %s" % str(query['operator']))
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(str(query['operator'])))
 
             opt += opt1
             opt += opt2
@@ -1216,11 +1216,11 @@ class Nipap:
             # val1 is variable, val2 is string.
 
             if query['val1'] not in _vrf_spec:
-                raise NipapInputError('Search variable \'%s\' unknown' % str(query['val1']))
+                raise NipapInputError('Search variable \'{0!s}\' unknown'.format(str(query['val1'])))
 
             # build where clause
             if query['operator'] not in _operation_map:
-                raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(query['operator']))
 
             # workaround for handling equal matches of NULL-values
             if query['operator'] == 'equals' and query['val2'] is None:
@@ -1229,13 +1229,11 @@ class Nipap:
                 query['operator'] = 'is_not'
 
             if query['operator'] in ('equals_any',):
-                where = str(" %%s = ANY (%s%s::citext[]) " %
-                        ( col_prefix, _vrf_spec[query['val1']]['column'])
+                where = str(" %s = ANY ({0!s}{1!s}::citext[]) ".format(col_prefix, _vrf_spec[query['val1']]['column'])
                         )
 
             else:
-                where = str(" %s%s %s %%s " %
-                    ( col_prefix, _vrf_spec[query['val1']]['column'],
+                where = str(" {0!s}{1!s} {2!s} %s ".format(col_prefix, _vrf_spec[query['val1']]['column'],
                     _operation_map[query['operator']] )
                 )
 
@@ -1263,7 +1261,7 @@ class Nipap:
             :py:func:`nipap.xmlrpc.NipapXMLRPC.add_vrf` for full understanding.
         """
 
-        self._logger.debug("add_vrf called; attr: %s" % str(attr))
+        self._logger.debug("add_vrf called; attr: {0!s}".format(str(attr)))
 
         # sanity check - do we have all attributes?
         req_attr = [ 'rt', 'name' ]
@@ -1285,11 +1283,11 @@ class Nipap:
             'authenticated_as': auth.authenticated_as,
             'full_name': auth.full_name,
             'authoritative_source': auth.authoritative_source,
-            'description': 'Added VRF %s with attr: %s' % (vrf['rt'], str(vrf))
+            'description': 'Added VRF {0!s} with attr: {1!s}'.format(vrf['rt'], str(vrf))
         }
 
         sql, params = self._sql_expand_insert(audit_params)
-        self._execute('INSERT INTO ip_net_log %s' % sql, params)
+        self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return vrf
 
@@ -1311,7 +1309,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("remove_vrf called; spec: %s" % str(spec))
+        self._logger.debug("remove_vrf called; spec: {0!s}".format(str(spec)))
 
         # get list of VRFs to remove before removing them
         vrfs = self.list_vrf(auth, spec)
@@ -1330,7 +1328,7 @@ class Nipap:
             self.remove_prefix(auth, spec = v6spec, recursive = True)
 
         where, params = self._expand_vrf_spec(spec)
-        sql = "DELETE FROM ip_net_vrf WHERE %s" % where
+        sql = "DELETE FROM ip_net_vrf WHERE {0!s}".format(where)
         self._execute(sql, params)
 
         # write to audit table
@@ -1343,10 +1341,10 @@ class Nipap:
                 'authenticated_as': auth.authenticated_as,
                 'full_name': auth.full_name,
                 'authoritative_source': auth.authoritative_source,
-                'description': 'Removed vrf %s' % v['rt']
+                'description': 'Removed vrf {0!s}'.format(v['rt'])
             }
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
 
 
@@ -1369,7 +1367,7 @@ class Nipap:
         if spec is None:
             spec = {}
 
-        self._logger.debug("list_vrf called; spec: %s" % str(spec))
+        self._logger.debug("list_vrf called; spec: {0!s}".format(str(spec)))
 
         sql = "SELECT * FROM ip_net_vrf"
 
@@ -1443,8 +1441,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("edit_vrf called; spec: %s attr: %s" %
-                (str(spec), str(attr)))
+        self._logger.debug("edit_vrf called; spec: {0!s} attr: {1!s}".format(str(spec), str(attr)))
 
         # sanity check - do we have all attributes?
         self._check_attr(attr, [], _vrf_attrs)
@@ -1476,10 +1473,10 @@ class Nipap:
                 'authenticated_as': auth.authenticated_as,
                 'full_name': auth.full_name,
                 'authoritative_source': auth.authoritative_source,
-                'description': 'Edited VRF %s attr: %s' % (v['rt'], str(attr))
+                'description': 'Edited VRF {0!s} attr: {1!s}'.format(v['rt'], str(attr))
             }
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return updated_vrfs
 
@@ -1595,7 +1592,7 @@ class Nipap:
                 raise NipapValueError('Invalid value for option' +
                     ''' 'offset'. Only integer values allowed.''')
 
-        self._logger.debug('search_vrf called; query: %s search_options: %s' % (str(query), str(search_options)))
+        self._logger.debug('search_vrf called; query: {0!s} search_options: {1!s}'.format(str(query), str(search_options)))
 
         opt = None
         sql = """ SELECT * FROM ip_net_vrf"""
@@ -1662,7 +1659,7 @@ class Nipap:
         if search_options is None:
             search_options = {}
 
-        self._logger.debug("smart_search_vrf query string: %s" % query_str)
+        self._logger.debug("smart_search_vrf query string: {0!s}".format(query_str))
 
         success, query = self._parse_vrf_query(query_str)
         if not success:
@@ -1681,7 +1678,7 @@ class Nipap:
                 'val2': extra_query
             }
 
-        self._logger.debug("smart_search_vrf; query expanded to: %s" % str(query))
+        self._logger.debug("smart_search_vrf; query expanded to: {0!s}".format(str(query)))
 
         search_result = self.search_vrf(auth, query, search_options)
         search_result['interpretation'] = query
@@ -1716,7 +1713,7 @@ class Nipap:
         allowed_values = ['id', 'name' ]
         for a in spec:
             if a not in allowed_values:
-                raise NipapExtraneousInputError("extraneous specification key %s" % a)
+                raise NipapExtraneousInputError("extraneous specification key {0!s}".format(a))
 
         if 'id' in spec:
             if type(spec['id']) not in (long, int):
@@ -1759,9 +1756,9 @@ class Nipap:
             sub_where1, opt1 = self._expand_pool_query(query['val1'], table_name)
             sub_where2, opt2 = self._expand_pool_query(query['val2'], table_name)
             try:
-                where += str(" (%s %s %s) " % (sub_where1, _operation_map[query['operator']], sub_where2) )
+                where += str(" ({0!s} {1!s} {2!s}) ".format(sub_where1, _operation_map[query['operator']], sub_where2) )
             except KeyError:
-                raise NipapNoSuchOperatorError("No such operator %s" % str(query['operator']))
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(str(query['operator'])))
 
             opt += opt1
             opt += opt2
@@ -1773,11 +1770,11 @@ class Nipap:
             # val1 is variable, val2 is string.
 
             if query['val1'] not in _pool_spec:
-                raise NipapInputError('Search variable \'%s\' unknown' % str(query['val1']))
+                raise NipapInputError('Search variable \'{0!s}\' unknown'.format(str(query['val1'])))
 
             # build where clause
             if query['operator'] not in _operation_map:
-                raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(query['operator']))
 
             # workaround for handling equal matches of NULL-values
             if query['operator'] == 'equals' and query['val2'] is None:
@@ -1786,13 +1783,11 @@ class Nipap:
                 query['operator'] = 'is_not'
 
             if query['operator'] in ('equals_any',):
-                where = str(" %%s = ANY (%s%s::citext[]) " %
-                        ( col_prefix, _pool_spec[query['val1']]['column'])
+                where = str(" %s = ANY ({0!s}{1!s}::citext[]) ".format(col_prefix, _pool_spec[query['val1']]['column'])
                         )
 
             else:
-                where = str(" %s%s %s %%s " %
-                    ( col_prefix, _pool_spec[query['val1']]['column'],
+                where = str(" {0!s}{1!s} {2!s} %s ".format(col_prefix, _pool_spec[query['val1']]['column'],
                     _operation_map[query['operator']] )
                 )
 
@@ -1819,7 +1814,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("add_pool called; attrs: %s" % str(attr))
+        self._logger.debug("add_pool called; attrs: {0!s}".format(str(attr)))
 
         # sanity check - do we have all attributes?
         req_attr = ['name', 'description', 'default_type']
@@ -1840,10 +1835,10 @@ class Nipap:
             'authenticated_as': auth.authenticated_as,
             'full_name': auth.full_name,
             'authoritative_source': auth.authoritative_source,
-            'description': 'Added pool %s with attr: %s' % (pool['name'], str(attr))
+            'description': 'Added pool {0!s} with attr: {1!s}'.format(pool['name'], str(attr))
         }
         sql, params = self._sql_expand_insert(audit_params)
-        self._execute('INSERT INTO ip_net_log %s' % sql, params)
+        self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return pool
 
@@ -1864,13 +1859,13 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("remove_pool called; spec: %s" % str(spec))
+        self._logger.debug("remove_pool called; spec: {0!s}".format(str(spec)))
 
         # fetch list of pools to remove before they are removed
         pools = self.list_pool(auth, spec)
 
         where, params = self._expand_pool_spec(spec)
-        sql = "DELETE FROM ip_net_pool AS po WHERE %s" % where
+        sql = "DELETE FROM ip_net_pool AS po WHERE {0!s}".format(where)
         self._execute(sql, params)
 
         # write to audit table
@@ -1883,10 +1878,10 @@ class Nipap:
         for p in pools:
             audit_params['pool_id'] = p['id'],
             audit_params['pool_name'] = p['name'],
-            audit_params['description'] = 'Removed pool %s' % p['name']
+            audit_params['description'] = 'Removed pool {0!s}'.format(p['name'])
 
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
 
 
@@ -1909,7 +1904,7 @@ class Nipap:
         if spec is None:
             spec = {}
 
-        self._logger.debug("list_pool called; spec: %s" % str(spec))
+        self._logger.debug("list_pool called; spec: {0!s}".format(str(spec)))
 
         sql = """SELECT DISTINCT (po.id),
                         po.id,
@@ -2035,8 +2030,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("edit_pool called; spec: %s attr: %s" %
-                (str(spec), str(attr)))
+        self._logger.debug("edit_pool called; spec: {0!s} attr: {1!s}".format(str(spec), str(attr)))
 
         if ('id' not in spec and 'name' not in spec) or ( 'id' in spec and 'name' in spec ):
             raise NipapMissingInputError('''pool spec must contain either 'id' or 'name' ''')
@@ -2067,10 +2061,10 @@ class Nipap:
         for p in pools:
             audit_params['pool_id'] = p['id']
             audit_params['pool_name'] = p['name']
-            audit_params['description'] = 'Edited pool %s attr: %s' % (p['name'], str(attr))
+            audit_params['description'] = 'Edited pool {0!s} attr: {1!s}'.format(p['name'], str(attr))
 
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return updated_pools
 
@@ -2186,7 +2180,7 @@ class Nipap:
                 raise NipapValueError('Invalid value for option' +
                     ''' 'offset'. Only integer values allowed.''')
 
-        self._logger.debug('search_pool search_options: %s' % str(search_options))
+        self._logger.debug('search_pool search_options: {0!s}'.format(str(search_options)))
 
         where, opt = self._expand_pool_query(query)
         sql = """SELECT DISTINCT (po.id),
@@ -2276,7 +2270,7 @@ class Nipap:
         if search_options is None:
             search_options = {}
 
-        self._logger.debug("smart_search_pool query string: %s" % query_str)
+        self._logger.debug("smart_search_pool query string: {0!s}".format(query_str))
 
         success, query = self._parse_pool_query(query_str)
         if not success:
@@ -2295,7 +2289,7 @@ class Nipap:
                 'val2': extra_query
             }
 
-        self._logger.debug("smart_search_pool; query expanded to: %s" % str(query))
+        self._logger.debug("smart_search_pool; query expanded to: {0!s}".format(str(query)))
 
         search_result = self.search_pool(auth, query, search_options)
         search_result['interpretation'] = query
@@ -2379,7 +2373,7 @@ class Nipap:
             else:
                 where += " AND family(" + prefix + "prefix) = %(family)s"
 
-        self._logger.debug("_expand_prefix_spec; where: %s params: %s" % (where, str(params)))
+        self._logger.debug("_expand_prefix_spec; where: {0!s} params: {1!s}".format(where, str(params)))
         return where, params
 
 
@@ -2412,9 +2406,9 @@ class Nipap:
             sub_where1, opt1 = self._expand_prefix_query(query['val1'], table_name)
             sub_where2, opt2 = self._expand_prefix_query(query['val2'], table_name)
             try:
-                where += str(" (%s %s %s) " % (sub_where1, _operation_map[query['operator']], sub_where2) )
+                where += str(" ({0!s} {1!s} {2!s}) ".format(sub_where1, _operation_map[query['operator']], sub_where2) )
             except KeyError:
-                raise NipapNoSuchOperatorError("No such operator %s" % str(query['operator']))
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(str(query['operator'])))
 
             opt += opt1
             opt += opt2
@@ -2426,11 +2420,11 @@ class Nipap:
             # val1 is key, val2 is value.
 
             if query['val1'] not in _prefix_spec:
-                raise NipapInputError('Search variable \'%s\' unknown' % str(query['val1']))
+                raise NipapInputError('Search variable \'{0!s}\' unknown'.format(str(query['val1'])))
 
             # build where clause
             if query['operator'] not in _operation_map:
-                raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(query['operator']))
 
             if query['val1'] == 'vrf_id' and query['val2'] is None:
                 query['val2'] = 0
@@ -2447,14 +2441,13 @@ class Nipap:
                     'contained_within',
                     'contained_within_equals'):
 
-                where = " iprange(prefix) %(operator)s %%s " % {
+                where = " iprange(prefix) {operator!s} %s ".format(**{
                         'col_prefix': col_prefix,
                         'operator': _operation_map[query['operator']]
-                        }
+                        })
 
             elif query['operator'] in ('equals_any',):
-                where = str(" %%s = ANY (%s%s::citext[]) " %
-                        ( col_prefix, _prefix_spec[query['val1']]['column'])
+                where = str(" %s = ANY ({0!s}{1!s}::citext[]) ".format(col_prefix, _prefix_spec[query['val1']]['column'])
                         )
 
             elif query['operator'] in (
@@ -2464,14 +2457,12 @@ class Nipap:
                 # we COALESCE column with '' to allow for example a regexp
                 # search on '.*' to match columns which are NULL in the
                 # database
-                where = str(" COALESCE(%s%s, '') %s %%s " %
-                        ( col_prefix, _prefix_spec[query['val1']]['column'],
+                where = str(" COALESCE({0!s}{1!s}, '') {2!s} %s ".format(col_prefix, _prefix_spec[query['val1']]['column'],
                         _operation_map[query['operator']] )
                         )
 
             else:
-                where = str(" %s%s %s %%s " %
-                        ( col_prefix, _prefix_spec[query['val1']]['column'],
+                where = str(" {0!s}{1!s} {2!s} %s ".format(col_prefix, _prefix_spec[query['val1']]['column'],
                         _operation_map[query['operator']] )
                         )
 
@@ -2525,7 +2516,7 @@ class Nipap:
         if args is None:
             args = {}
 
-        self._logger.debug("add_prefix called; attr: %s; args: %s" % (str(attr), str(args)))
+        self._logger.debug("add_prefix called; attr: {0!s}; args: {1!s}".format(str(attr), str(args)))
 
         # args defined?
         if args is None:
@@ -2671,18 +2662,18 @@ class Nipap:
             'authenticated_as': auth.authenticated_as,
             'full_name': auth.full_name,
             'authoritative_source': auth.authoritative_source,
-            'description': 'Added prefix %s with attr: %s' % (prefix['prefix'], str(attr))
+            'description': 'Added prefix {0!s} with attr: {1!s}'.format(prefix['prefix'], str(attr))
         }
         sql, params = self._sql_expand_insert(audit_params)
-        self._execute('INSERT INTO ip_net_log %s' % sql, params)
+        self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         if pool['id'] is not None:
             audit_params['pool_id'] = pool['id']
             audit_params['pool_name'] = pool['name']
-            audit_params['description'] = 'Pool %s expanded with prefix %s in VRF %s' % (pool['name'], prefix['prefix'], str(prefix['vrf_rt']))
+            audit_params['description'] = 'Pool {0!s} expanded with prefix {1!s} in VRF {2!s}'.format(pool['name'], prefix['prefix'], str(prefix['vrf_rt']))
 
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return prefix
 
@@ -2709,8 +2700,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("edit_prefix called; spec: %s attr: %s" %
-                (str(spec), str(attr)))
+        self._logger.debug("edit_prefix called; spec: {0!s} attr: {1!s}".format(str(spec), str(attr)))
 
         # Handle Pool - find correct one and remove bad pool keys
         pool = None
@@ -2786,9 +2776,9 @@ class Nipap:
             audit_params['vrf_name'] = p['vrf_name']
             audit_params['prefix_id'] = p['id']
             audit_params['prefix_prefix'] = p['prefix']
-            audit_params['description'] = 'Edited prefix %s attr: %s' % (p['prefix'], str(attr))
+            audit_params['description'] = 'Edited prefix {0!s} attr: {1!s}'.format(p['prefix'], str(attr))
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
             # Only add to log if something was changed
             if p['pool_id'] != pool['id']:
@@ -2810,10 +2800,10 @@ class Nipap:
 
                     audit_params2['pool_id'] = pool['id']
                     audit_params2['pool_name'] = pool['name']
-                    audit_params2['description'] = 'Expanded pool %s with prefix %s' % (pool['name'], p['prefix'])
+                    audit_params2['description'] = 'Expanded pool {0!s} with prefix {1!s}'.format(pool['name'], p['prefix'])
 
                     sql, params = self._sql_expand_insert(audit_params2)
-                    self._execute('INSERT INTO ip_net_log %s' % sql, params)
+                    self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
                 # if prefix had pool set previously, prefix was removed from that pool
                 if p['pool_id'] is not None:
@@ -2822,10 +2812,10 @@ class Nipap:
 
                     audit_params2['pool_id'] = pool2['id']
                     audit_params2['pool_name'] = pool2['name']
-                    audit_params2['description'] = 'Removed prefix %s from pool %s' % (p['prefix'], pool2['name'])
+                    audit_params2['description'] = 'Removed prefix {0!s} from pool {1!s}'.format(p['prefix'], pool2['name'])
 
                     sql, params = self._sql_expand_insert(audit_params2)
-                    self._execute('INSERT INTO ip_net_log %s' % sql, params)
+                    self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return updated_prefixes
 
@@ -2934,7 +2924,7 @@ class Nipap:
                 if self._get_afi(p) == int(args['family']):
                     prefixes.append(p)
             if len(prefixes) == 0:
-                raise NipapInputError('No prefixes of family %s in pool' % str(args['family']))
+                raise NipapInputError('No prefixes of family {0!s} in pool'.format(str(args['family'])))
             if 'prefix_length' not in args:
                 if int(args['family']) == 4:
                     wpl = pool_result[0]['ipv4_default_prefix_length']
@@ -3016,7 +3006,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("list_prefix called; spec: %s" % str(spec))
+        self._logger.debug("list_prefix called; spec: {0!s}".format(str(spec)))
 
 
         if type(spec) is dict:
@@ -3036,8 +3026,8 @@ class Nipap:
             inp.prefix,
             inp.display_prefix,
             inp.description,
-            COALESCE(inp.inherited_tags, '{}') AS inherited_tags,
-            COALESCE(inp.tags, '{}') AS tags,
+            COALESCE(inp.inherited_tags, '{{}}') AS inherited_tags,
+            COALESCE(inp.tags, '{{}}') AS tags,
             inp.node,
             inp.comment,
             pool.id AS pool_id,
@@ -3062,8 +3052,8 @@ class Nipap:
             inp.expires
             FROM ip_net_plan inp
             JOIN ip_net_vrf vrf ON (inp.vrf_id = vrf.id)
-            LEFT JOIN ip_net_pool pool ON (inp.pool_id = pool.id) %s
-            ORDER BY vrf.rt NULLS FIRST, prefix""" % where
+            LEFT JOIN ip_net_pool pool ON (inp.pool_id = pool.id) {0!s}
+            ORDER BY vrf.rt NULLS FIRST, prefix""".format(where)
 
         self._execute(sql, params)
 
@@ -3090,7 +3080,7 @@ class Nipap:
         else:
             where, params = self._expand_prefix_spec(spec)
 
-        sql = "DELETE FROM ip_net_plan AS p WHERE %s" % where
+        sql = "DELETE FROM ip_net_plan AS p WHERE {0!s}".format(where)
         self._execute(sql, params)
 
 
@@ -3110,7 +3100,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("remove_prefix called; spec: %s" % str(spec))
+        self._logger.debug("remove_prefix called; spec: {0!s}".format(str(spec)))
 
         # sanity check - do we have all attributes?
         if 'id' in spec:
@@ -3144,12 +3134,12 @@ class Nipap:
         for p in prefixes:
             audit_params['prefix_id'] = p['id']
             audit_params['prefix_prefix'] = p['prefix']
-            audit_params['description'] = 'Removed prefix %s' % p['prefix']
+            audit_params['description'] = 'Removed prefix {0!s}'.format(p['prefix'])
             audit_params['vrf_id'] = p['vrf_id']
             audit_params['vrf_rt'] = p['vrf_rt']
             audit_params['vrf_name'] = p['vrf_name']
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
             if p['pool_id'] is not None:
                 pool = self._get_pool(auth, { 'id': p['pool_id'] })
@@ -3158,14 +3148,14 @@ class Nipap:
                     'pool_name': pool['name'],
                     'prefix_id': p['id'],
                     'prefix_prefix': p['prefix'],
-                    'description': 'Prefix %s removed from pool %s' % (p['prefix'], pool['name']),
+                    'description': 'Prefix {0!s} removed from pool {1!s}'.format(p['prefix'], pool['name']),
                     'username': auth.username,
                     'authenticated_as': auth.authenticated_as,
                     'full_name': auth.full_name,
                     'authoritative_source': auth.authoritative_source
                 }
                 sql, params = self._sql_expand_insert(audit_params2)
-                self._execute('INSERT INTO ip_net_log %s' % sql, params)
+                self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
 
 
@@ -3325,7 +3315,7 @@ class Nipap:
         else:
             if search_options['include_all_parents'] not in (True, False):
                 raise NipapValueError('Invalid value for option ' +
-                    "'include_all_parents'. Only true and false valid. Supplied value :'%s'" % str(search_options['include_all_parents']))
+                    "'include_all_parents'. Only true and false valid. Supplied value :'{0!s}'".format(str(search_options['include_all_parents'])))
 
         # include_children
         if 'include_all_children' not in search_options:
@@ -3333,7 +3323,7 @@ class Nipap:
         else:
             if search_options['include_all_children'] not in (True, False):
                 raise NipapValueError('Invalid value for option ' +
-                    "'include_all_children'. Only true and false valid. Supplied value: '%s'" % str(search_options['include_all_children']))
+                    "'include_all_children'. Only true and false valid. Supplied value: '{0!s}'".format(str(search_options['include_all_children'])))
 
         # parents_depth
         if 'parents_depth' not in search_options:
@@ -3361,7 +3351,7 @@ class Nipap:
         else:
             if search_options['include_neighbors'] not in (True, False):
                 raise NipapValueError('Invalid value for option ' +
-                    "'include_neighbors'. Only true and false valid. Supplied value: '%s'" % str(search_options['include_neighbors']))
+                    "'include_neighbors'. Only true and false valid. Supplied value: '{0!s}'".format(str(search_options['include_neighbors'])))
 
         # max_result
         if 'max_result' not in search_options:
@@ -3395,28 +3385,27 @@ class Nipap:
                 _ = int(search_options['parent_prefix'])
             except ValueError:
                 raise NipapValueError(
-                    "Invalid value '%s' for option 'parent_prefix'. Must be the ID of a prefix."
-                        % search_options['parent_prefix'])
+                    "Invalid value '{0!s}' for option 'parent_prefix'. Must be the ID of a prefix.".format(search_options['parent_prefix']))
             try:
                 parent_prefix = self.list_prefix(auth, { 'id': search_options['parent_prefix'] })[0]
             except IndexError:
-                raise NipapNonExistentError("Parent prefix %s can not be found" % search_options['parent_prefix'])
+                raise NipapNonExistentError("Parent prefix {0!s} can not be found".format(search_options['parent_prefix']))
 
-        self._logger.debug('search_prefix search_options: %s' % str(search_options))
+        self._logger.debug('search_prefix search_options: {0!s}'.format(str(search_options)))
 
         # translate search options to SQL
 
         if search_options['include_all_parents'] or search_options['parents_depth'] == -1:
             where_parents = ''
         elif search_options['parents_depth'] >= 0:
-            where_parents = 'AND p1.indent BETWEEN p2.indent - %d AND p1.indent' % search_options['parents_depth']
+            where_parents = 'AND p1.indent BETWEEN p2.indent - {0:d} AND p1.indent'.format(search_options['parents_depth'])
         else:
             raise NipapValueError("Invalid value for option 'parents_depth'. Only integer values > -1 allowed.")
 
         if search_options['include_all_children'] or search_options['children_depth'] == -1:
             where_children = ''
         elif search_options['children_depth'] >= 0:
-            where_children = 'AND p1.indent BETWEEN p2.indent AND p2.indent + %d' % search_options['children_depth']
+            where_children = 'AND p1.indent BETWEEN p2.indent AND p2.indent + {0:d}'.format(search_options['children_depth'])
         else:
             raise NipapValueError("Invalid value for option 'children_depth'. Only integer values > -1 allowed.")
 
@@ -3429,7 +3418,7 @@ class Nipap:
             vrf_id = 0
             if parent_prefix['vrf_id']:
                 vrf_id = parent_prefix['vrf_id']
-            where_parent_prefix = " WHERE (p1.vrf_id = %s AND iprange(p1.prefix) <<= iprange('%s') AND p1.indent <= %s) " % (vrf_id, parent_prefix['prefix'], parent_prefix['indent'] + 1)
+            where_parent_prefix = " WHERE (p1.vrf_id = {0!s} AND iprange(p1.prefix) <<= iprange('{1!s}') AND p1.indent <= {2!s}) ".format(vrf_id, parent_prefix['prefix'], parent_prefix['indent'] + 1)
             left_join = 'LEFT OUTER'
         else:
             where_parent_prefix = ''
@@ -3438,9 +3427,9 @@ class Nipap:
         if search_options['max_result'] is None:
             limit_string = ""
         else:
-            limit_string = "LIMIT %d" % (search_options['max_result'] + search_options['offset'])
+            limit_string = "LIMIT {0:d}".format((search_options['max_result'] + search_options['offset']))
 
-        display = '(p1.prefix << p2.display_prefix OR p2.prefix <<= p1.prefix %s) OR (p2.prefix >>= p1.prefix %s)' % (where_parents, where_children)
+        display = '(p1.prefix << p2.display_prefix OR p2.prefix <<= p1.prefix {0!s}) OR (p2.prefix >>= p1.prefix {1!s})'.format(where_parents, where_children)
 
         where, opt = self._expand_prefix_query(query)
         sql = """
@@ -3617,7 +3606,7 @@ class Nipap:
         if search_options is None:
             search_options = {}
 
-        self._logger.debug("smart_search_prefix query string: %s" % query_str)
+        self._logger.debug("smart_search_prefix query string: {0!s}".format(query_str))
 
         success, query = self._parse_prefix_query(query_str)
         if not success:
@@ -3636,7 +3625,7 @@ class Nipap:
                 'val2': extra_query
             }
 
-        self._logger.debug("smart_search_prefix: query expanded to: %s" % str(query))
+        self._logger.debug("smart_search_prefix: query expanded to: {0!s}".format(str(query)))
 
         search_result = self.search_prefix(auth, query, search_options)
         search_result['interpretation'] = query
@@ -3685,9 +3674,9 @@ class Nipap:
             sub_where1, opt1 = self._expand_asn_query(query['val1'], table_name)
             sub_where2, opt2 = self._expand_asn_query(query['val2'], table_name)
             try:
-                where += str(" (%s %s %s) " % (sub_where1, _operation_map[query['operator']], sub_where2) )
+                where += str(" ({0!s} {1!s} {2!s}) ".format(sub_where1, _operation_map[query['operator']], sub_where2) )
             except KeyError:
-                raise NipapNoSuchOperatorError("No such operator %s" % str(query['operator']))
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(str(query['operator'])))
 
             opt += opt1
             opt += opt2
@@ -3702,7 +3691,7 @@ class Nipap:
             asn_attr['name'] = 'name'
 
             if query['val1'] not in asn_attr:
-                raise NipapInputError('Search variable \'%s\' unknown' % str(query['val1']))
+                raise NipapInputError('Search variable \'{0!s}\' unknown'.format(str(query['val1'])))
 
             # workaround for handling equal matches of NULL-values
             if query['operator'] == 'equals' and query['val2'] is None:
@@ -3712,10 +3701,9 @@ class Nipap:
 
             # build where clause
             if query['operator'] not in _operation_map:
-                raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(query['operator']))
 
-            where = str(" %s%s %s %%s " %
-                ( col_prefix, asn_attr[query['val1']],
+            where = str(" {0!s}{1!s} {2!s} %s ".format(col_prefix, asn_attr[query['val1']],
                 _operation_map[query['operator']] )
             )
 
@@ -3741,7 +3729,7 @@ class Nipap:
         allowed_values = ['asn', 'name']
         for a in spec:
             if a not in allowed_values:
-                raise NipapExtraneousInputError("extraneous specification key %s" % a)
+                raise NipapExtraneousInputError("extraneous specification key {0!s}".format(a))
 
         if 'asn' in spec:
             if type(spec['asn']) not in (int, long):
@@ -3780,7 +3768,7 @@ class Nipap:
         if asn is None:
             asn = {}
 
-        self._logger.debug("list_asn called; asn: %s" % str(asn))
+        self._logger.debug("list_asn called; asn: {0!s}".format(str(asn)))
 
         sql = "SELECT * FROM ip_net_asn"
         params = list()
@@ -3818,7 +3806,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("add_asn called; attr: %s" % str(attr))
+        self._logger.debug("add_asn called; attr: {0!s}".format(str(attr)))
 
         # sanity check - do we have all attributes?
         req_attr = [ 'asn', ]
@@ -3837,11 +3825,11 @@ class Nipap:
             'authenticated_as': auth.authenticated_as,
             'full_name': auth.full_name,
             'authoritative_source': auth.authoritative_source,
-            'description': 'Added ASN %s with attr: %s' % (attr['asn'], str(attr))
+            'description': 'Added ASN {0!s} with attr: {1!s}'.format(attr['asn'], str(attr))
         }
 
         sql, params = self._sql_expand_insert(audit_params)
-        self._execute('INSERT INTO ip_net_log %s' % sql, params)
+        self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return asn
 
@@ -3864,8 +3852,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("edit_asn called; asn: %s attr: %s" %
-                (str(asn), str(attr)))
+        self._logger.debug("edit_asn called; asn: {0!s} attr: {1!s}".format(str(asn), str(attr)))
 
         # sanity check - do we have all attributes?
         req_attr = [ ]
@@ -3894,10 +3881,10 @@ class Nipap:
                 'full_name': auth.full_name,
                 'authoritative_source': auth.authoritative_source
             }
-            audit_params['description'] = 'Edited ASN %s attr: %s' % (str(a['asn']), str(attr))
+            audit_params['description'] = 'Edited ASN {0!s} attr: {1!s}'.format(str(a['asn']), str(attr))
 
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
         return updated_asns
 
@@ -3920,7 +3907,7 @@ class Nipap:
             understanding.
         """
 
-        self._logger.debug("remove_asn called; asn: %s" % str(asn))
+        self._logger.debug("remove_asn called; asn: {0!s}".format(str(asn)))
 
         # get list of ASNs to remove before removing them
         asns = self.list_asn(auth, asn)
@@ -3937,10 +3924,10 @@ class Nipap:
                 'authenticated_as': auth.authenticated_as,
                 'full_name': auth.full_name,
                 'authoritative_source': auth.authoritative_source,
-                'description': 'Removed ASN %s' % str(a['asn'])
+                'description': 'Removed ASN {0!s}'.format(str(a['asn']))
             }
             sql, params = self._sql_expand_insert(audit_params)
-            self._execute('INSERT INTO ip_net_log %s' % sql, params)
+            self._execute('INSERT INTO ip_net_log {0!s}'.format(sql), params)
 
 
 
@@ -4022,7 +4009,7 @@ class Nipap:
                 raise NipapValueError('Invalid value for option' +
                     ''' 'offset'. Only integer values allowed.''')
 
-        self._logger.debug('search_asn search_options: %s' % str(search_options))
+        self._logger.debug('search_asn search_options: {0!s}'.format(str(search_options)))
 
         opt = None
         sql = """ SELECT * FROM ip_net_asn """
@@ -4085,7 +4072,7 @@ class Nipap:
         if search_options is None:
             search_options = {}
 
-        self._logger.debug("smart_search_asn called; query_str: %s" % query_str)
+        self._logger.debug("smart_search_asn called; query_str: {0!s}".format(query_str))
 
         success, query = self._parse_asn_query(query_str)
         if not success:
@@ -4104,7 +4091,7 @@ class Nipap:
                 'val2': extra_query
             }
 
-        self._logger.debug("smart_search_asn; query expanded to: %s" % str(query))
+        self._logger.debug("smart_search_asn; query expanded to: {0!s}".format(str(query)))
 
         search_result = self.search_asn(auth, query, search_options)
         search_result['interpretation'] = query
@@ -4209,9 +4196,9 @@ class Nipap:
             sub_where1, opt1 = self._expand_tag_query(query['val1'], table_name)
             sub_where2, opt2 = self._expand_tag_query(query['val2'], table_name)
             try:
-                where += str(" (%s %s %s) " % (sub_where1, _operation_map[query['operator']], sub_where2) )
+                where += str(" ({0!s} {1!s} {2!s}) ".format(sub_where1, _operation_map[query['operator']], sub_where2) )
             except KeyError:
-                raise NipapNoSuchOperatorError("No such operator %s" % str(query['operator']))
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(str(query['operator'])))
 
             opt += opt1
             opt += opt2
@@ -4225,7 +4212,7 @@ class Nipap:
             tag_attr['name'] = 'name'
 
             if query['val1'] not in tag_attr:
-                raise NipapInputError('Search variable \'%s\' unknown' % str(query['val1']))
+                raise NipapInputError('Search variable \'{0!s}\' unknown'.format(str(query['val1'])))
 
             # workaround for handling equal matches of NULL-values
             if query['operator'] == 'equals' and query['val2'] is None:
@@ -4235,10 +4222,9 @@ class Nipap:
 
             # build where clause
             if query['operator'] not in _operation_map:
-                raise NipapNoSuchOperatorError("No such operator %s" % query['operator'])
+                raise NipapNoSuchOperatorError("No such operator {0!s}".format(query['operator']))
 
-            where = str(" %s%s %s %%s " %
-                ( col_prefix, tag_attr[query['val1']],
+            where = str(" {0!s}{1!s} {2!s} %s ".format(col_prefix, tag_attr[query['val1']],
                 _operation_map[query['operator']] )
             )
 
@@ -4326,7 +4312,7 @@ class Nipap:
                 raise NipapValueError('Invalid value for option' +
                     ''' 'offset'. Only integer values allowed.''')
 
-        self._logger.debug('search_tag search_options: %s' % str(search_options))
+        self._logger.debug('search_tag search_options: {0!s}'.format(str(search_options)))
 
         opt = None
         sql = """ SELECT * FROM (SELECT DISTINCT unnest(tags) AS name FROM

--- a/nipap/nipap/daemon.py
+++ b/nipap/nipap/daemon.py
@@ -54,7 +54,7 @@ def createDaemon():
       # to insure that the next call to os.setsid is successful.
       pid = os.fork()
    except OSError as exc:
-      raise Exception, "%s [%d]" % (exc.strerror, exc.errno)
+      raise Exception, "{0!s} [{1:d}]".format(exc.strerror, exc.errno)
 
    if (pid == 0):   # The first child.
       # To become the session leader of this new session and the process group
@@ -102,7 +102,7 @@ def createDaemon():
          # a controlling terminal.
          pid = os.fork()    # Fork a second child.
       except OSError as exc:
-         raise Exception, "%s [%d]" % (exc.strerror, exc.errno)
+         raise Exception, "{0!s} [{1:d}]".format(exc.strerror, exc.errno)
 
       if (pid == 0):    # The second child.
          # Since the current working directory may be a mounted filesystem, we
@@ -191,16 +191,16 @@ if __name__ == "__main__":
    # process ID, process group ID, and its parent's process ID.
 
    procParams = """
-   return code = %s
-   process ID = %s
-   parent process ID = %s
-   process group ID = %s
-   session ID = %s
-   user ID = %s
-   effective user ID = %s
-   real group ID = %s
-   effective group ID = %s
-   """ % (retCode, os.getpid(), os.getppid(), os.getpgrp(), os.getsid(0),
+   return code = {0!s}
+   process ID = {1!s}
+   parent process ID = {2!s}
+   process group ID = {3!s}
+   session ID = {4!s}
+   user ID = {5!s}
+   effective user ID = {6!s}
+   real group ID = {7!s}
+   effective group ID = {8!s}
+   """.format(retCode, os.getpid(), os.getppid(), os.getpgrp(), os.getsid(0),
    os.getuid(), os.geteuid(), os.getgid(), os.getegid())
 
    open("createDaemon.log", "w").write(procParams + "\n")

--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -179,7 +179,7 @@ class SmartParser:
         success = True
         dse = None
         for part, lookahead in izip_longest(ast, ast[1:]):
-            self._logger.debug("part: %s %s" % (part, part.getName()))
+            self._logger.debug("part: {0!s} {1!s}".format(part, part.getName()))
 
             # handle operators joining together expressions
             if part.getName() == 'boolean':
@@ -206,16 +206,16 @@ class SmartParser:
             elif part.getName() in ('ipv6_prefix', 'ipv6_address', 'word', 'tag', 'vrf_rt', 'quoted_string'):
                 # dict sql expression
                 dse = self._string_to_dictsql(part)
-                self._logger.debug('string part: %s  => %s' % (part, dse))
+                self._logger.debug('string part: {0!s}  => {1!s}'.format(part, dse))
             else:
-                raise ParserError("Unhandled part in AST: %s %s" % (part,
+                raise ParserError("Unhandled part in AST: {0!s} {1!s}".format(part,
                                                                     part.getName()))
 
             if dss['val1'] is None:
-                self._logger.debug('val1 not set, using dse: %s' % unicode(dse))
+                self._logger.debug('val1 not set, using dse: {0!s}'.format(unicode(dse)))
                 dss['val1'] = dse
             else:
-                self._logger.debug("val1 is set, operator is '%s', val2 = dst: %s" % (dss['operator'], unicode(dse)))
+                self._logger.debug("val1 is set, operator is '{0!s}', val2 = dst: {1!s}".format(dss['operator'], unicode(dse)))
                 dss['val2'] = dse
 
             if lookahead is not None:

--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -81,8 +81,8 @@ def requires_auth(f):
             raise Fault(1000, ("NIPAP API functions take exactly 1 argument (%d given)") % len(args))
 
         if type(nipap_args) != dict:
-            raise Fault(1000, ("Function argument must be XML-RPC struct/Python dict (Python %s given)." %
-                type(nipap_args).__name__ ))
+            raise Fault(1000, ("Function argument must be XML-RPC struct/Python dict (Python {0!s} given).".format(
+                type(nipap_args).__name__) ))
 
         # fetch auth options
         try:

--- a/nipap/xml-test.py
+++ b/nipap/xml-test.py
@@ -18,7 +18,7 @@ cred = ''
 if args.user and args.password:
 	cred = args.user + ':' + args.password + '@'
 
-server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': args.port, 'cred': cred }
+server_url = 'http://{cred!s}127.0.0.1:{port:d}/XMLRPC'.format(**{ 'port': args.port, 'cred': cred })
 server = xmlrpclib.Server(server_url, allow_none=1);
 
 ad = { 'authoritative_source': 'nipap' }

--- a/nipap/xmlbench.py
+++ b/nipap/xmlbench.py
@@ -46,7 +46,7 @@ class Request():
         self.__returned()
         self.finished = True
         self.error = error
-        self.error_file.write("Error: %s" % error)
+        self.error_file.write("Error: {0!s}".format(error))
         self.callback(self,error)
 
 
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     cred = ''
     if args.user and args.password:
         cred = args.user + ':' + args.password + '@'
-    server_url = 'http://%(cred)s127.0.0.1:%(port)d/XMLRPC' % { 'port': args.port, 'cred': cred }
+    server_url = 'http://{cred!s}127.0.0.1:{port:d}/XMLRPC'.format(**{ 'port': args.port, 'cred': cred })
 
     ad = { 'authoritative_source': 'nipap' }
     args = [{ 'auth': ad, 'message': 'test', 'sleep': 0.1 }]

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -498,9 +498,9 @@ class VRF(Pynipap):
         # cached?
         if CACHE:
             if id in _cache['VRF']:
-                log.debug('cache hit for VRF %d' % id)
+                log.debug('cache hit for VRF {0:d}'.format(id))
                 return _cache['VRF'][id]
-            log.debug('cache miss for VRF %d' % id)
+            log.debug('cache miss for VRF {0:d}'.format(id))
 
         try:
             vrf = VRF.list({ 'id': id })[0]
@@ -630,7 +630,7 @@ class VRF(Pynipap):
                 raise _fault_to_exception(xml_fault)
 
             if len(vrfs) != 1:
-                raise NipapError('VRF edit returned %d entries, should be 1.' % len(vrfs))
+                raise NipapError('VRF edit returned {0:d} entries, should be 1.'.format(len(vrfs)))
             vrf = vrfs[0]
 
         # Refresh object data with attributes from add/edit operation
@@ -744,7 +744,7 @@ class Pool(Pynipap):
                 raise _fault_to_exception(xml_fault)
 
             if len(pools) != 1:
-                raise NipapError('Pool edit returned %d entries, should be 1.' % len(pools))
+                raise NipapError('Pool edit returned {0:d} entries, should be 1.'.format(len(pools)))
             pool = pools[0]
 
         # Refresh object data with attributes from add/edit operation
@@ -784,9 +784,9 @@ class Pool(Pynipap):
         # cached?
         if CACHE:
             if id in _cache['Pool']:
-                log.debug('cache hit for pool %d' % id)
+                log.debug('cache hit for pool {0:d}'.format(id))
                 return _cache['Pool'][id]
-            log.debug('cache miss for pool %d' % id)
+            log.debug('cache miss for pool {0:d}'.format(id))
 
         try:
             pool = Pool.list({'id': id})[0]
@@ -990,9 +990,9 @@ class Prefix(Pynipap):
         # cached?
         if CACHE:
             if id in _cache['Prefix']:
-                log.debug('cache hit for prefix %d' % id)
+                log.debug('cache hit for prefix {0:d}'.format(id))
                 return _cache['Prefix'][id]
-            log.debug('cache miss for prefix %d' % id)
+            log.debug('cache miss for prefix {0:d}'.format(id))
 
         try:
             prefix = Prefix.list({'id': id})[0]
@@ -1243,7 +1243,7 @@ class Prefix(Pynipap):
                 raise _fault_to_exception(xml_fault)
 
             if len(prefixes) != 1:
-                raise NipapError('Prefix edit returned %d entries, should be 1.' % len(prefixes))
+                raise NipapError('Prefix edit returned {0:d} entries, should be 1.'.format(len(prefixes)))
             prefix = prefixes[0]
 
         # Refresh object data with attributes from add/edit operation

--- a/tests/nipapbase.py
+++ b/tests/nipapbase.py
@@ -323,7 +323,7 @@ class NipapTest(unittest.TestCase):
         pool_id = self.nipap.add_pool(self.auth, schema, attrs)
         pool = self.nipap.list_pool(self.auth, schema, { 'id': pool_id })
         for a in attrs:
-            self.assertEqual(pool[0][a], attrs[a], 'Added object differ from listed on attribute: %s  %s!=%s' % (a, attrs[a], pool[0][a]))
+            self.assertEqual(pool[0][a], attrs[a], 'Added object differ from listed on attribute: {0!s}  {1!s}!={2!s}'.format(a, attrs[a], pool[0][a]))
 
 
 
@@ -514,13 +514,13 @@ class NipapTest(unittest.TestCase):
         query_str = ""
         for key, val in query_keys.items():
             if val == "description":
-                query_str += "\"%s\" " % key
+                query_str += "\"{0!s}\" ".format(key)
             else:
-                query_str += "%s " % key
+                query_str += "{0!s} ".format(key)
 
         res = self.nipap.smart_search_prefix(self.auth, schema, query_str)
         for interp in res['interpretation']:
-            self.assertEqual(interp['string'] in query_keys, True, "Function returned unknown interpreted string %s" % interp['string'])
+            self.assertEqual(interp['string'] in query_keys, True, "Function returned unknown interpreted string {0!s}".format(interp['string']))
 
         prefix_attrs = {
                 'authoritative_source': 'nipap-test',

--- a/tests/performance/speedtest.py
+++ b/tests/performance/speedtest.py
@@ -59,7 +59,7 @@ class bonk:
                         for o3 in xrange(os3, 255):
                             t2 = time.time()
                             for o4 in xrange(os4, 255):
-                                prefix = "%s.%s.%s.%s" % (o1, o2, o3, o4)
+                                prefix = "{0!s}.{1!s}.{2!s}.{3!s}".format(o1, o2, o3, o4)
                                 self.n.list_prefix({ 'name': 'test-schema'}, { 'prefix': prefix })
                                 i += 1
                                 if i >= count:
@@ -98,7 +98,7 @@ class bonk:
                         for o3 in xrange(os3, 255):
                             t2 = time.time()
                             for o4 in xrange(os4, 255):
-                                prefix = "%s.%s.%s.%s" % (o1, o2, o3, o4)
+                                prefix = "{0!s}.{1!s}.{2!s}.{3!s}".format(o1, o2, o3, o4)
                                 self.n.add_prefix({'name': 'test-schema' }, { 'prefix': prefix, 'description': 'test' })
                                 i += 1
                                 if i >= count:

--- a/utilities/boilerplate.py
+++ b/utilities/boilerplate.py
@@ -32,14 +32,14 @@ if __name__ == '__main__':
     parser.add_argument('--port', help="NIPAP backend port")
     args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+    auth_uri = "{0!s}:{1!s}@".format(args.username or cfg.get('global', 'username'),
             args.password or cfg.get('global', 'password'))
 
-    xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
+    xmlrpc_uri = "http://{auth_uri!s}{host!s}:{port!s}".format(**{
             'auth_uri'  : auth_uri,
             'host'      : args.host or cfg.get('global', 'hostname'),
             'port'      : args.port or cfg.get('global', 'port')
-            }
+            })
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 

--- a/utilities/bulk-string-replace.py
+++ b/utilities/bulk-string-replace.py
@@ -78,7 +78,7 @@ def replace(pattern, replacement):
         n += 1
 
     t1 = time.time()
-    print " done in %.1f seconds" % (t1 - t0)
+    print " done in {0:.1f} seconds".format((t1 - t0))
 
     # Display list
     print_pattern = "%-2s%-14s%-2s%-30s%-20s%s"
@@ -88,7 +88,7 @@ def replace(pattern, replacement):
     for i, prefix in enumerate(prefix_list):
         if prefix.match:
             print COLOR_RESET,
-            print " -- %d --" % i
+            print " -- {0:d} --".format(i)
             color = COLOR_RED
         else:
             color = COLOR_RESET
@@ -141,7 +141,7 @@ def replace(pattern, replacement):
         try:
             selection = map(lambda x: int(x.strip()), selection)
         except ValueError as e:
-            print >> sys.stderr, "Could not parse selection: %s" % str(e)
+            print >> sys.stderr, "Could not parse selection: {0!s}".format(str(e))
             sys.exit(1)
 
     for i, prefix in enumerate(prefix_list):
@@ -152,7 +152,7 @@ def replace(pattern, replacement):
             if prefix.description is not None:
                 prefix.description = re.sub(pattern, replacement, prefix.description, flags=re.IGNORECASE)
 
-            print "Saving prefix %s..." % prefix.display_prefix
+            print "Saving prefix {0!s}...".format(prefix.display_prefix)
             prefix.save()
 
 if __name__ == '__main__':
@@ -173,14 +173,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Set up NIPAP
-    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+    auth_uri = "{0!s}:{1!s}@".format(args.username or cfg.get('global', 'username'),
             args.password or cfg.get('global', 'password'))
 
-    xmlrpc_uri = "http://%(auth_uri)s[%(host)s]:%(port)s" % {
+    xmlrpc_uri = "http://{auth_uri!s}[{host!s}]:{port!s}".format(**{
             'auth_uri'  : auth_uri,
             'host'      : args.host or cfg.get('global', 'hostname'),
             'port'      : args.port or cfg.get('global', 'port')
-            }
+            })
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 

--- a/utilities/convert.py
+++ b/utilities/convert.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
         curs_pg_old = con_pg_old.cursor(cursor_factory=psycopg2.extras.DictCursor)
         curs_pg_old2 = con_pg_old.cursor(cursor_factory=psycopg2.extras.DictCursor)
     except Exception, e:
-        print 'pgsql: %s' % e
+        print 'pgsql: {0!s}'.format(e)
         sys.exit(1)
 
     _register_inet(conn_or_curs = con_pg_old)
@@ -125,7 +125,7 @@ if __name__ == '__main__':
         curs_pg_new = con_pg_new.cursor(cursor_factory=psycopg2.extras.DictCursor)
         curs_pg_new2 = con_pg_new.cursor(cursor_factory=psycopg2.extras.DictCursor)
     except Exception, e:
-        print 'pgsql: %s' % e
+        print 'pgsql: {0!s}'.format(e)
         sys.exit(1)
 
     _register_inet(conn_or_curs = con_pg_new)
@@ -152,7 +152,7 @@ if __name__ == '__main__':
         try:
             p.save()
         except NipapError, e:
-            print "ERR: %s" % str(e)
+            print "ERR: {0!s}".format(str(e))
         pools[r['id']] = p
 
         # remove new audit log entries
@@ -184,7 +184,7 @@ if __name__ == '__main__':
             try:
                 v.save()
             except NipapError, e:
-                print "ERR: %s" % str(e)
+                print "ERR: {0!s}".format(str(e))
             vrfs[v.rt] = v
             s_vrfs[r['id']] = v
     print "done"
@@ -197,7 +197,7 @@ if __name__ == '__main__':
     for r in curs_pg_old:
         if re.match('^\d+:\d+$', r['vrf'].strip()):
 
-            print "Found VRF %s" % r['vrf']
+            print "Found VRF {0!s}".format(r['vrf'])
             
             # skip if VRF already added
             if r['vrf'].strip() in vrfs:
@@ -209,12 +209,12 @@ if __name__ == '__main__':
             try:
                 v.save()
             except NipapError, e:
-                print "ERR: %s" % str(e)
+                print "ERR: {0!s}".format(str(e))
             vrfs[v.rt] = v
 
         elif re.match('^\d+$', r['vrf'].strip()):
 
-            print "Found VRF %s" % r['vrf']
+            print "Found VRF {0!s}".format(r['vrf'])
 
             # skip if VRF already added
             if '1257:' + r['vrf'].strip() in vrfs:
@@ -228,12 +228,12 @@ if __name__ == '__main__':
             try:
                 v.save()
             except NipapError, e:
-                print "ERR: %s" % str(e)
+                print "ERR: {0!s}".format(str(e))
             vrfs[v.rt] = v
             vrfs[r['vrf'].strip()] = v
 
         else:
-            print "Found invalid VRF %s" % str(r['vrf'])
+            print "Found invalid VRF {0!s}".format(str(r['vrf']))
 
     print "done"
 
@@ -271,12 +271,12 @@ if __name__ == '__main__':
         try:
             p.save()
         except NipapError, e:
-            print "ERR: %s" % str(e),
-            print "Prefix: pref: %s old_id: %d" % (p.prefix, r['id'])
+            print "ERR: {0!s}".format(str(e)),
+            print "Prefix: pref: {0!s} old_id: {1:d}".format(p.prefix, r['id'])
 
         i += 1
         if i % 500 == 0:
-            print "%.1f pps" % (500/(time.time() - t))
+            print "{0:.1f} pps".format((500/(time.time() - t)))
             t = time.time()
 
         # update audit log
@@ -299,7 +299,7 @@ if __name__ == '__main__':
                     pool_name = pools[r['pool']].name
                     pool_id = pools[r['pool']].id
                 else:
-                    print "Pool %s not found" % str(ar['pool'])
+                    print "Pool {0!s} not found".format(str(ar['pool']))
  
             # figure out VRF stuff
             vrf_id = 0

--- a/utilities/export-csv.py
+++ b/utilities/export-csv.py
@@ -62,13 +62,13 @@ if __name__ == '__main__':
 
     auth_uri = ''
     if args.username:
-        auth_uri = "%s:%s@" % (args.username, args.password)
+        auth_uri = "{0!s}:{1!s}@".format(args.username, args.password)
 
-    xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
+    xmlrpc_uri = "http://{auth_uri!s}{host!s}:{port!s}".format(**{
             'auth_uri'  : auth_uri,
             'host'      : args.host,
             'port'      : args.port
-            }
+            })
 
     wr = Export(xmlrpc_uri)
     wr.write(args.file, args.query)

--- a/utilities/export-template.py
+++ b/utilities/export-template.py
@@ -81,14 +81,14 @@ if __name__ == '__main__':
     parser.add_argument('--query', default='', help="query for filtering prefixes")
     args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+    auth_uri = "{0!s}:{1!s}@".format(args.username or cfg.get('global', 'username'),
             args.password or cfg.get('global', 'password'))
 
-    xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
+    xmlrpc_uri = "http://{auth_uri!s}{host!s}:{port!s}".format(**{
             'auth_uri'  : auth_uri,
             'host'      : args.host or cfg.get('global', 'hostname'),
             'port'      : args.port or cfg.get('global', 'port')
-            }
+            })
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 

--- a/utilities/remove-all.py
+++ b/utilities/remove-all.py
@@ -43,14 +43,14 @@ if __name__ == '__main__':
                       help="disable interactive prompting of actions")
     args = parser.parse_args()
 
-    auth_uri = "%s:%s@" % (args.username or cfg.get('global', 'username'),
+    auth_uri = "{0!s}:{1!s}@".format(args.username or cfg.get('global', 'username'),
             args.password or cfg.get('global', 'password'))
 
-    xmlrpc_uri = "http://%(auth_uri)s%(host)s:%(port)s" % {
+    xmlrpc_uri = "http://{auth_uri!s}{host!s}:{port!s}".format(**{
             'auth_uri'  : auth_uri,
             'host'      : args.host or cfg.get('global', 'hostname'),
             'port'      : args.port or cfg.get('global', 'port')
-            }
+            })
     pynipap.AuthOptions({ 'authoritative_source': 'nipap' })
     pynipap.xmlrpc_uri = xmlrpc_uri
 

--- a/whoisd/nipap_whoisd.py
+++ b/whoisd/nipap_whoisd.py
@@ -38,7 +38,7 @@ def createDaemon():
       # to insure that the next call to os.setsid is successful.
       pid = os.fork()
    except OSError, e:
-      raise Exception, "%s [%d]" % (e.strerror, e.errno)
+      raise Exception, "{0!s} [{1:d}]".format(e.strerror, e.errno)
 
    if (pid == 0):   # The first child.
       # To become the session leader of this new session and the process group
@@ -86,7 +86,7 @@ def createDaemon():
          # a controlling terminal.
          pid = os.fork()    # Fork a second child.
       except OSError, e:
-         raise Exception, "%s [%d]" % (e.strerror, e.errno)
+         raise Exception, "{0!s} [{1:d}]".format(e.strerror, e.errno)
 
       if (pid == 0):    # The second child.
          # Since the current working directory may be a mounted filesystem, we


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SpriteLink:NIPAP?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SpriteLink:NIPAP?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)