### PR TITLE
Match inherited tags

### DIFF
--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -467,15 +467,23 @@ class PrefixSmartParser(SmartParser):
             dictsql = {
                     'interpretation': {
                         'string': part[0],
-                        'interpretation': 'tag',
+                        'interpretation': '(inherited) tag',
                         'attribute': 'tag',
                         'operator': 'equals_any',
                         'error': False
-                        },
-                    'operator': 'equals_any',
-                    'val1': 'tags',
-                    'val2': part[0][1:]
+                    },
+                    'operator': 'or',
+                    'val1': {
+                        'operator': 'equals_any',
+                        'val1': 'tags',
+                        'val2': part[0][1:]
+                    },
+                    'val2': {
+                        'operator': 'equals_any',
+                        'val1': 'inherited_tags',
+                        'val2': part[0][1:]
                     }
+            }
 
         elif part.getName() == 'vrf_rt':
             self._logger.debug("Query part '" + part.vrf_rt + "' interpreted as VRF RT")

--- a/nipap/sql/Makefile
+++ b/nipap/sql/Makefile
@@ -38,6 +38,7 @@ db:
 	-psql -q -c "ALTER USER $(DB_USER) ENCRYPTED PASSWORD '$(DB_PASS)'"
 	-psql -d $(DB_NAME) -c "CREATE EXTENSION ip4r;"
 	-psql -d $(DB_NAME) -c "CREATE EXTENSION hstore;"
+	-psql -d $(DB_NAME) -c "CREATE EXTENSION citext;"
 
 
 tables:


### PR DESCRIPTION
Update the smart parser to match tags against a prefix's inherited as well as "own" tags.

Fixes #1055.