### PR TITLE
Explicitly depend on python-webob >= 1.2

### DIFF
--- a/nipap-www/debian/control
+++ b/nipap-www/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.1
 
 Package: nipap-www
 Architecture: all
-Depends: debconf, python (>= 2.7), ${misc:Depends}, python-pylons (>=1.0), python-pynipap, nipap-common, python-jinja2
+Depends: debconf, python (>= 2.7), ${misc:Depends}, python-pylons (>=1.0), python-pynipap, nipap-common, python-jinja2, python-webob (>=1.2)
 XB-Python-Version: ${python:Versions}
 Description: web frontend for NIPAP
  A web UI for the NIPAP IP address planning service.


### PR DESCRIPTION
The request.json attribute wich is used to extract the JSON data which is POST:ed to the web server was not available until WebOb 1.2.0. Thus, adding an explicit dependency on this or greater versions.

Fixes #1066.