### PR TITLE
Document recursive prefix remove

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -3108,6 +3108,8 @@ class Nipap:
                 AAA options.
             * `spec` [prefix_spec]
                 Specifies prefixe to remove.
+            * `recursive` [bool]
+                When set to True, also remove child prefixes.
 
             This is the documentation of the internal backend function. It's
             exposed over XML-RPC, please also see the XML-RPC documentation for

--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -665,6 +665,8 @@ class NipapXMLRPC:
                 Authentication options passed to the :class:`AuthFactory`.
             * `prefix` [struct]
                 Attributes used to select what prefix to remove.
+            * `recursive` [boolean]
+                When set to 1, also remove child prefixes.
         """
         try:
             return self.nip.remove_prefix(args.get('auth'), args.get('prefix'), args.get('recursive'))


### PR DESCRIPTION
Added documentation of the `recursive` option to the remove_prefix function.