### PR TITLE
Add support for recursive prefix remove

### DIFF
--- a/jnipap/JnipapTester.java
+++ b/jnipap/JnipapTester.java
@@ -11,6 +11,7 @@ import jnipap.Prefix;
 import jnipap.Connection;
 import jnipap.AddPrefixOptions;
 import jnipap.JnipapException;
+import jnipap.DuplicateException;
 
 import org.junit.Before;
 import org.junit.After;
@@ -248,6 +249,62 @@ public class JnipapTester {
 			fail("Smart seach operation resulted in " + e.getClass().getName() + " with message \"" + e.getMessage() + "\"");
 		}
 
+	}
+
+	/**
+	 * Test adding prefixes and performing a recursive remove
+	 */
+	@Test
+	public void addRecursiveRemovePrefix() {
+
+		// Add a parent and child prefix
+		Prefix prefix1, prefix2, prefix3;
+		prefix1 = new Prefix();
+		prefix1.prefix = "11.0.0.0/8";
+		prefix1.type = "reservation";
+		prefix1.description = "RFC1918 class A block";
+
+		prefix2 = new Prefix();
+		prefix2.prefix = "11.0.0.0/24";
+		prefix2.type = "assignment";
+		prefix2.description = "subnet";
+
+		prefix3 = new Prefix();
+		prefix3.prefix = "11.0.0.1/32";
+		prefix3.type = "host";
+		prefix3.description = "TEST TEST";
+
+		try {
+			prefix1.save(this.connection);
+			prefix2.save(this.connection);
+			prefix3.save(this.connection);
+		} catch (JnipapException e) {
+			fail("Save operation resulted in " + e.getClass().getName() + " with message \"" + e.getMessage() + "\"");
+		}
+
+		// Perform a recursive remove of the added prefixes
+		try {
+			prefix1.remove(this.connection, Boolean.TRUE);
+		} catch (JnipapException e) {
+			fail("Save operation resulted in " + e.getClass().getName() + " with message \"" + e.getMessage() + "\"");
+		}
+
+		// Search!
+		try {
+			// Add option to include all children
+			Map opts = new HashMap<String, Object>();
+			opts.put("children_depth", -1);
+
+			Map result = Prefix.search(this.connection, "11.0.0.0/8", opts);
+
+			int len = ((List)result.get("result")).size();
+			if (len > 0) {
+				fail("Smart search operation returned too many elements (" + len + "), should be 0");
+			}
+
+		} catch (JnipapException e) {
+			fail("Smart seach operation resulted in " + e.getClass().getName() + " with message \"" + e.getMessage() + "\"");
+		}
 
 	}
 

--- a/jnipap/jnipap/AuthFailedException.java
+++ b/jnipap/jnipap/AuthFailedException.java
@@ -3,7 +3,7 @@ package jnipap;
 /**
  * Thrown when authentication against NIPAP service fails.
  */
-class AuthFailedException extends JnipapException {
+public class AuthFailedException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/ConnectionException.java
+++ b/jnipap/jnipap/ConnectionException.java
@@ -5,7 +5,7 @@ package jnipap;
  *
  * Timeouts, ...
  */
-class ConnectionException extends JnipapException {
+public class ConnectionException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/DuplicateException.java
+++ b/jnipap/jnipap/DuplicateException.java
@@ -5,7 +5,7 @@ package jnipap;
  *
  * For example, when creating a VRF which already exists.
  */
-class DuplicateException extends JnipapException {
+public class DuplicateException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/InvalidParameterException.java
+++ b/jnipap/jnipap/InvalidParameterException.java
@@ -3,7 +3,7 @@ package jnipap;
 /**
  * Thrown when invalid parameters were received
  */
-class InvalidParameterException extends JnipapException {
+public class InvalidParameterException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/MissingInputException.java
+++ b/jnipap/jnipap/MissingInputException.java
@@ -5,7 +5,7 @@ package jnipap;
  *
  * This can probably be a RuntimeError instead
  */
-class MissingInputException extends InputException {
+public class MissingInputException extends InputException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/NonExistentException.java
+++ b/jnipap/jnipap/NonExistentException.java
@@ -6,7 +6,7 @@ package jnipap;
  * Thrown when for example trying to get a prefix from a pool which does not
  * exist or using the .get()-method on an ID which does not exist.
  */
-class NonExistentException extends JnipapException {
+public class NonExistentException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;

--- a/jnipap/jnipap/Prefix.java
+++ b/jnipap/jnipap/Prefix.java
@@ -195,6 +195,19 @@ public class Prefix extends Jnipap {
 	 */
 	public void remove(Connection conn) throws JnipapException {
 
+		// Perform non-recursive remove
+		this.remove(conn, Boolean.FALSE);
+
+	}
+
+	/**
+	 * Remove object from NIPAP
+	 *
+	 * @param conn Connection with auth options
+	 * @param recursive When set to true, also remove child prefixes
+	 */
+	public void remove(Connection conn, Boolean recursive) throws JnipapException {
+
 		// Build prefix spec
 		HashMap prefix_spec = new HashMap();
 		prefix_spec.put("id", this.id);
@@ -203,6 +216,7 @@ public class Prefix extends Jnipap {
 		HashMap args = new HashMap();
 		args.put("auth", conn.authMap());
 		args.put("prefix", prefix_spec);
+		args.put("recursive", recursive);
 
 		List params = new ArrayList();
 		params.add(args);
@@ -500,7 +514,7 @@ public class Prefix extends Jnipap {
 				(country != null && country.equals(pref.country))) &&
 			(order_id == pref.order_id ||
 				(order_id != null && order_id.equals(pref.order_id))) &&
-            (customer_id == pref.customer_id ||
+			(customer_id == pref.customer_id ||
 				(customer_id != null && customer_id.equals(pref.customer_id))) &&
 			(external_key == pref.external_key ||
 				(external_key != null &&

--- a/jnipap/jnipap/ValueException.java
+++ b/jnipap/jnipap/ValueException.java
@@ -5,7 +5,7 @@ package jnipap;
  * Thrown for example when an integer is specified when an IP address is
  * expected.
  */
-class ValueException extends JnipapException {
+public class ValueException extends JnipapException {
 
 	// version ID for serialization
 	private static final long serialVersionUID = 0L;


### PR DESCRIPTION
Added support for recursive prefix remove to jnipap, including a simple test case. The feature was added by overloading the previously existing remove()-function, so the old API is still intact and the change shouldn't break old code using the library.