### PR TITLE
Fix list_prefix with family arg

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -2378,11 +2378,11 @@ class Nipap:
         # prefix family needs to be handled separately as it's not stored
         # explicitly in the database
         if family:
-            params['family'] = family
             if len(params) == 0:
                 where = "family(" + prefix + "prefix) = %(family)s"
             else:
                 where += " AND family(" + prefix + "prefix) = %(family)s"
+            params['family'] = family
 
         self._logger.debug("_expand_prefix_spec; where: %s params: %s" % (where, unicode(params)))
         return where, params


### PR DESCRIPTION
Heh, can't check len(params) == 0 when we set it on the line above,
guaranteeing it will always be at least 1...

Fixes #1091.