### PR TITLE
Only show add-prefix-from-prefix option when it's usable

### DIFF
--- a/nipap-www/nipapwww/public/nipap.js
+++ b/nipap-www/nipapwww/public/nipap.js
@@ -841,7 +841,10 @@ function showPrefixMenu(prefix_id) {
 			var dialog = showDialogYesNo('Really remove prefix?', confirmation_text, confirmation_action);
         });
 
-		menu.append('<a href="/ng/prefix#/prefix/add/from-prefix/' + prefix_id + '">Add prefix from prefix</a>');
+		// Add button to add prefix from prefix, unless it's of max prefix length
+		if (!hasMaxPreflen(prefix_list[prefix_id])) {
+			menu.append('<a href="/ng/prefix#/prefix/add/from-prefix/' + prefix_id + '">Add prefix from prefix</a>');
+		}
 
 	}
 


### PR DESCRIPTION
Don't show the "Add prefix from prefix"-option in the prefix list popup menu when clicking prefixes with max prefix length, as no prefixes can be allocated from these.

Fixes #863