### PR TITLE
Fix handling of monitor-attribute

### DIFF
--- a/nipap-www/nipapwww/controllers/xhr.py
+++ b/nipap-www/nipapwww/controllers/xhr.py
@@ -589,10 +589,7 @@ class XhrController(BaseController):
         if 'alarm_priority' in request.json:
             p.alarm_priority = validate_string(request.json, 'alarm_priority')
         if 'monitor' in request.json:
-            if request.json['monitor'] == 'true':
-                p.monitor = True
-            else:
-                p.monitor = False
+            p.monitor = request.json['monitor']
 
         if 'vlan' in request.json:
             p.vlan = request.json['vlan']
@@ -664,11 +661,7 @@ class XhrController(BaseController):
             if 'alarm_priority' in request.json:
                 p.alarm_priority = validate_string(request.json, 'alarm_priority')
             if 'monitor' in request.json:
-                if request.json['monitor'] == 'true':
-                    p.monitor = True
-                else:
-                    p.monitor = False
-
+                p.monitor = request.json['monitor']
             if 'country' in request.json:
                 p.country = validate_string(request.json, 'country')
             if 'order_id' in request.json:


### PR DESCRIPTION
Since the change from sending data from the client to the server side of the web UI with a POST containing JSON data, the handling of the monitor attribute has been broken in the web UI. The broken behaviour lead to it not only being impossible to change the monitor attribute from the web UI, but that it was disabled whenever updating a prefix in the web UI.

Fixes #1130