### PR TITLE
Re-enable parsing of query string in URL

### DIFF
--- a/nipap-www/nipapwww/templates/prefix_list.html
+++ b/nipap-www/nipapwww/templates/prefix_list.html
@@ -14,12 +14,12 @@
 	function handleUrlQuery() {
 
 		// Is there a query string in the URL?
-		if ($.url().fparam('query_string') == null) {
+		if ($.url().fparam('/query_string') == null) {
 			return true;
 		}
 
 		// query_string
-		$("#query_string").val(decodeURIComponent($.url().fparam('query_string')));
+		$("#query_string").val(decodeURIComponent($.url().fparam('/query_string')));
 
 		// search_opt_parent
 		if ($.url().fparam('search_opt_parent') != null) {


### PR DESCRIPTION
Since the last upgrade of AngularJS, the part of the URL to the right of the hash has been prefixed with a slash. The library used to parse the URL considers the slash as part of the name of the parameter and thus the name needs to be updated when accessing it.

With this change, the URL is again successfully parsed.

This is a hack to re-enable the functionality lost with the AngularJS upgrade. This will all be replaced with an AngularJS implementation of the prefix list page.

Fixes #1115
Fixes #1089