### PR TITLE
Updated file path for paster invocation in docs

### DIFF
--- a/docs/config-www.rst
+++ b/docs/config-www.rst
@@ -37,10 +37,10 @@ Using paster is the easiest way to get the NIPAP web UI up and running, but
 it's not really suitable for production deployment. To serve the NIPAP web UI
 from paster, run the following::
 
-    paster serve /etc/nipap/www/nipap-www.ini
+    paster serve /etc/nipap/nipap-www.ini
 
 Using the default configuration, the web UI should now be reachable on port
-5000. To change the port, edit /etc/nipap/www/nipap-www.ini.
+5000. To change the port, edit /etc/nipap/nipap-www.ini.
 
 Apache httpd with mod_wsgi
 ==========================


### PR DESCRIPTION
Just a bug fix.

```
root@jessie:/home/vagrant/NIPAP# ls /etc/nipap/www
nipap-www.wsgi
```
```
root@jessie:/home/vagrant/NIPAP# paster serve /etc/nipap/nipap-www.ini
Starting server in PID 1689.
serving on 0.0.0.0:5000 view at http://127.0.0.1:5000
```