### PR TITLE
Adding protocol independency for nipap-cli

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -77,6 +77,7 @@ if __name__ == '__main__':
 
     # config defaults
     cfg_defaults = {
+        'protocol': 'http',
         'hostname': 'localhost',
         'post': 1337,
         'password': None,
@@ -97,11 +98,12 @@ if __name__ == '__main__':
 
         nipapd_version = 'unknown'
         try:
-            pynipap.xmlrpc_uri = "http://%(username)s:%(password)s@%(hostname)s:%(port)s" % {
+            pynipap.xmlrpc_uri = "%(protocol)s://%(username)s:%(password)s@%(hostname)s:%(port)s" % {
                     'username': nipap_cli.nipap_cli.cfg.get('global', 'username'),
                     'password': nipap_cli.nipap_cli.cfg.get('global', 'password'),
                     'hostname': nipap_cli.nipap_cli.cfg.get('global', 'hostname'),
-                    'port'    : nipap_cli.nipap_cli.cfg.get('global', 'port')
+                    'port'    : nipap_cli.nipap_cli.cfg.get('global', 'port'),
+                    'protocol': nipap_cli.nipap_cli.cfg.get('global', 'protocol'),
                 }
             ao = pynipap.AuthOptions({'authoritative_source': 'nipap'})
             nipapd_version = pynipap.nipapd_version()

--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -57,7 +57,8 @@ def setup_connection():
             'username': os.getenv('NIPAP_USERNAME') or cfg.get('global', 'username'),
             'password': os.getenv('NIPAP_PASSWORD') or cfg.get('global', 'password'),
             'hostname': os.getenv('NIPAP_HOST') or cfg.get('global', 'hostname'),
-            'port'    : os.getenv('NIPAP_PORT') or cfg.get('global', 'port')
+            'port'    : os.getenv('NIPAP_PORT') or cfg.get('global', 'port'),
+            'protocol': os.getenv('NIPAP_PROTOCOL') or cfg.get('global', 'protocol')
         }
     except (configparser.NoOptionError, configparser.NoSectionError) as exc:
         print("ERROR:", str(exc), file=sys.stderr)
@@ -71,7 +72,7 @@ def setup_connection():
         con_params['password'] = getpass.getpass()
 
     # build XML-RPC URI
-    pynipap.xmlrpc_uri = "http://%(username)s:%(password)s@%(hostname)s:%(port)s" % con_params
+    pynipap.xmlrpc_uri = "%(protocol)s://%(username)s:%(password)s@%(hostname)s:%(port)s" % con_params
 
     ao = pynipap.AuthOptions({
         'authoritative_source': 'nipap',


### PR DESCRIPTION
Allow nipap-cli to communicate with nipapd via https and http.