### PR TITLE
Fix path for AuthOptions

### DIFF
--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -84,7 +84,7 @@
     each consecutive instances will be copies of the first one. In this way the
     authentication options can be accessed from all of the pynipap classes. ::
 
-        a = AuthOptions({
+        a = pynipap.AuthOptions({
                 'authoritative_source': 'my_fancy_nipap_client'
             })
 


### PR DESCRIPTION
The example shows importing pynipap and directly importing some names like VRF,
Prefix and Pool but AuthOption is not among them so we would need to refer to it
as pynipap.AuthOption. It's important we are consistent in our documentation.