### PR TITLE
Add Freebsd support

### DIFF
--- a/nipap-cli/setup.py
+++ b/nipap-cli/setup.py
@@ -22,11 +22,18 @@ def get_data_files():
         print("rst2man failed to run:", str(exc), file=sys.stderr)
         sys.exit(1)
 
+    if sys.platform.startswith('freebsd'):
+        localbase = '/usr/local'
+        etcdir = localbase + '/etc'
+    else:
+        localbase = '/usr'
+        etcdir = '/etc'
+
     files = [
-            ('/etc/skel/', ['.nipaprc']),
-            ('/usr/bin/', ['helper-nipap', 'nipap']),
-            ('/usr/share/doc/nipap-cli/', ['bash_complete', 'nipaprc']),
-            ('/usr/share/man/man1/', ['nipap.1'])
+            (etcdir + '/skel/', ['.nipaprc']),
+            (localbase + '/bin/', ['helper-nipap', 'nipap']),
+            (localbase + '/share/doc/nipap-cli/', ['bash_complete', 'nipaprc']),
+            (localbase + '/share/man/man1/', ['nipap.1'])
         ]
 
     return files

--- a/nipap-www/setup.py
+++ b/nipap-www/setup.py
@@ -1,6 +1,13 @@
 from setuptools import setup, find_packages
 import nipapwww
 
+if sys.platform.startswith('freebsd'):
+    localbase = '/usr/local'
+    etcdir = localbase + '/etc'
+else:
+    localbase = '/usr'
+    etcdir = '/etc'
+
 setup(
     name='nipap-www',
     version=nipapwww.__version__,
@@ -20,14 +27,6 @@ setup(
     include_package_data=True,
     test_suite='nose.collector',
     package_data={'nipapwww': ['i18n/*/LC_MESSAGES/*.mo']},
-
-    if sys.platform.startswith('freebsd'):
-        localbase = '/usr/local'
-        etcdir = localbase + '/etc'
-    else:
-        localbase = '/usr'
-        etcdir = '/etc'
-
     data_files = [
         ( etcdir + '/nipap/', [ 'nipap-www.ini', ] ),
         ( etcdir + '/nipap/www', [ 'nipap-www.wsgi', ] ),
@@ -46,3 +45,4 @@ setup(
     main = pylons.util:PylonsInstaller
     """,
 )
+

--- a/nipap-www/setup.py
+++ b/nipap-www/setup.py
@@ -20,9 +20,17 @@ setup(
     include_package_data=True,
     test_suite='nose.collector',
     package_data={'nipapwww': ['i18n/*/LC_MESSAGES/*.mo']},
+
+    if sys.platform.startswith('freebsd'):
+        localbase = '/usr/local'
+        etcdir = localbase + '/etc'
+    else:
+        localbase = '/usr'
+        etcdir = '/etc'
+
     data_files = [
-        ( '/etc/nipap/', [ 'nipap-www.ini', ] ),
-        ( '/etc/nipap/www', [ 'nipap-www.wsgi', ] ),
+        ( etcdir + '/nipap/', [ 'nipap-www.ini', ] ),
+        ( etcdir + '/nipap/www', [ 'nipap-www.wsgi', ] ),
         ( '/var/cache/nipap-www/', [] )
     ],
     #message_extractors={'nipapwww': [

--- a/nipap-www/setup.py
+++ b/nipap-www/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-import nipapwww
+import nipapwww, sys
 
 if sys.platform.startswith('freebsd'):
     localbase = '/usr/local'

--- a/nipap/nipap/smart_parsing.py
+++ b/nipap/nipap/smart_parsing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from itertools import izip_longest

--- a/nipap/setup.py
+++ b/nipap/setup.py
@@ -17,10 +17,17 @@ def get_data_files():
         print >> sys.stderr, "rst2man failed to run:", str(exc)
         sys.exit(1)
 
+    if sys.platform.startswith('freebsd'):
+        localbase = '/usr/local'
+        etcdir = localbase + '/etc'
+    else:
+        localbase = '/usr'
+        etcdir = '/etc'
+
     files = [
-            ('/etc/nipap/', ['nipap.conf.dist']),
-            ('/usr/sbin/', ['nipapd', 'nipap-passwd']),
-            ('/usr/share/nipap/sql/', [
+            (etcdir + '/nipap/', ['nipap.conf.dist']),
+            (localbase + '/sbin/', ['nipapd', 'nipap-passwd']),
+            (localbase + '/share/nipap/sql/', [
                 'sql/upgrade-1-2.plsql',
                 'sql/upgrade-2-3.plsql',
                 'sql/upgrade-3-4.plsql',
@@ -30,8 +37,8 @@ def get_data_files():
                 'sql/triggers.plsql',
                 'sql/ip_net.plsql'
                 ]),
-            ('/usr/share/man/man8/', ['nipapd.8']),
-            ('/usr/share/man/man1/', ['nipap-passwd.1'])
+            (localbase + '/share/man/man8/', ['nipapd.8']),
+            (localbase + '/share/man/man1/', ['nipap-passwd.1'])
         ]
 
     return files

--- a/utilities/boilerplate.py
+++ b/utilities/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ This is a boilerplate for interacting with NIPAP using Pynipap
 
     It provides things such as basic command line parsing of connection options

--- a/utilities/export-template.py
+++ b/utilities/export-template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ This is a generic file exporter for NIPAP
 
     It fetches prefixes based on a provided query string and feeds that into a

--- a/utilities/remove-all.py
+++ b/utilities/remove-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ This script helps you remove all pools, prefixes or VRFs stored in NIPAP
 
     It can be useful when working on import script and you want to run many


### PR DESCRIPTION
Patches to add FreeBSD support.

Mainly handles path issues in setup.py files, also changes some shebang lines to /usr/bin/env instead of hardcoding python paths. 

nipapd, nipap-www and nipap-cli all build, install and run well on FreeBSD with this patch. Changes have not been tested on Debian but I expect no issues.

I am open to discussing whether "if sys.platform.startswith('freebsd'):" is the right way to do this, but at least it works.