### PR TITLE
Use sync bind for searching, needed by MS AD

### DIFF
--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -387,7 +387,8 @@ class LdapAuth(BaseAuth):
         try:
             # Create separate connection for search?
             if self._ldap_search_conn is not None:
-                self._ldap_search_conn.simple_bind_s(self._ldap_search_binddn, self._ldap_search_password)
+                self._ldap_search_conn.simple_bind_s(
+                    self._ldap_search_binddn, self._ldap_search_password)
                 search_conn = self._ldap_search_conn
             else:
                 search_conn = self._ldap_conn


### PR DESCRIPTION
With my corp MS AD, I get: 
00002024: LdapErr: DSID-0C0605D4, comment: No other operations may be performed on the connection while a bind is outstanding., data 0, v1db1
without the '_s', and it works with it - if this is intentionally async, then it should be configurable I think?

PS. complete newbie in python/ldap/nipap, so please don't shoot me :/