### PR TITLE
Change psql concurrency from autocommit to serializable.

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -771,7 +771,7 @@ class Nipap:
         while True:
             try:
                 self._con_pg = psycopg2.connect(**db_args)
-                self._con_pg.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+                self._con_pg.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE)
                 self._curs_pg = self._con_pg.cursor(cursor_factory=psycopg2.extras.DictCursor)
                 self._register_inet()
                 psycopg2.extras.register_hstore(self._con_pg, globally=True, unicode=True)


### PR DESCRIPTION
Psql Autocommit is giving concurrency errors in PostgreSQL when operations are sent in parallel. Using serializable transactions seems to fix it.

Example:

```ERROR:  deadlock detected
DETAIL:  Process 176184 waits for ShareLock on transaction 15529683; blocked by process 191002.
 Process 191002 waits for ShareLock on transaction 15529684; blocked by process 178678.
 Process 178678 waits for ExclusiveLock on tuple (1386,16) of relation 43815 of database 16391; blocked by process 176184.
 Process 176184: DELETE FROM ip_net_plan AS p WHERE vrf_id = 0 AND prefix = '10.0.10.240/28'
 Process 191002: DELETE FROM ip_net_plan AS p WHERE vrf_id = 0 AND prefix = '10.0.11.0/28'
 Process 178678: DELETE FROM ip_net_plan AS p WHERE vrf_id = 0 AND prefix = '10.0.10.208/28'
HINT:  See server log for query details.
CONTEXT:  while locking tuple (1386,16) in relation "ip_net_plan"
 SQL statement "UPDATE ip_net_plan SET children =
      (SELECT COUNT(1)
      FROM ip_net_plan
      WHERE vrf_id = OLD.vrf_id
       AND iprange(prefix) << iprange(old_parent.prefix)
       AND indent = old_parent.indent+1)
     WHERE id = old_parent.id"
 PL/pgSQL function tf_ip_net_plan__prefix_iu_after() line 92 at SQL statement
STATEMENT:  DELETE FROM ip_net_plan AS p WHERE vrf_id = 0 AND prefix = '10.0.10.240/28'
```

This problem is happening pretty often in our deployment (several times per day).

I can easily reproduce it with this simple (and partial) Python code. `list_of_prefixes` is a file with a prefix on each line:

```    procs = {}
    with open('list_of_prefixes') as f:
        lines = f.readlines()
    for line in lines:
        line = line.strip('\n')
        procs[line] = multiprocessing.Process(target=delete_prefix, args=(ipam, line,))
    for _, obj in procs.items():
        obj.start()
    for _, obj in procs.items():
        obj.join()
```

I guess this patch only hides the problem, but changing every query/transaction/function would not be as easy.
