### PR TITLE
Fixed removal of extra attributes

### DIFF
--- a/nipap-www/nipapwww/public/templates/prefix_form.html
+++ b/nipap-www/nipapwww/public/templates/prefix_form.html
@@ -306,7 +306,7 @@ PREFIX DATA
 									<input type="text" style="width: 100%;" ng-model="avp.value">
 								</td>
 								<td class="col-md-1" style="padding-top: 3px; padding-bottom: 3px;">
-									<button type="button" class="btn btn-xs btn-danger" ng-click="removeAvp(avp.attribute)">
+									<button type="button" class="btn btn-xs btn-danger" ng-click="removeAvp(avp)">
 										<span class="glyphicon glyphicon-minus"></span> Remove
 									</button>
 								</td>


### PR DESCRIPTION
Fixes a bug where the last extra attribute added to a prefix would be removed, no matter which one was clicked.

Fixes #1205