### PR TITLE
nipap/xmlrpc: update legacy flask extension import

### DIFF
--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -13,7 +13,7 @@ from functools import wraps
 from flask import Flask
 from flask import request, Response
 from flaskext.xmlrpc import XMLRPCHandler, Fault
-from flask.ext.compress import Compress
+from flask_compress import Compress
 
 from nipapconfig import NipapConfig
 from backend import Nipap, NipapError


### PR DESCRIPTION
Updated the flask.ext.compress import to the new underscore format.

## Reason
This actually broke on an ancient Ubuntu xenial server I upgraded recently.
I had to edit `xmlrpc.py` and insert the correct import.

Towards #946 