### PR TITLE
Bump Werkzeug dependency to 0.16.1

### DIFF
--- a/nipap/requirements.txt
+++ b/nipap/requirements.txt
@@ -4,7 +4,7 @@ Flask-XML-RPC==0.1.2
 IPy==0.83
 Jinja2==2.10.1
 MarkupSafe==1.0
-Werkzeug==0.12.2
+Werkzeug==0.15.3
 backports.ssl-match-hostname==3.5.0.1
 certifi==2017.4.17
 itsdangerous==0.24

--- a/nipap/requirements.txt
+++ b/nipap/requirements.txt
@@ -4,7 +4,7 @@ Flask-XML-RPC==0.1.2
 IPy==0.83
 Jinja2==2.10.1
 MarkupSafe==1.0
-Werkzeug==0.15.3
+Werkzeug==0.16.1
 backports.ssl-match-hostname==3.5.0.1
 certifi==2017.4.17
 itsdangerous==0.24


### PR DESCRIPTION
Bump to Werkzeug 0.16.1. Replaces #1232 which suggests 0.15.3 which has a bug with Python 2.7.5.