### PR TITLE
fix(nipap-cli): Allow `None` as ConfigParser values

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         'prefix_list_columns': None
     }
     # read configuration
-    cfg = configparser.ConfigParser(cfg_defaults)
+    cfg = configparser.ConfigParser(cfg_defaults, allow_no_value=True)
     cfg.read(userrcfile)
     nipap_cli.nipap_cli.cfg = cfg
 


### PR DESCRIPTION
It seems that newer python versions (I'm on python 3.8) do not accept
`None` by default. Adding the `allow_no_value` argument fixes that.