### PR TITLE
Use `install` to install bash completion script

### DIFF
--- a/nipap-cli/debian/postinst
+++ b/nipap-cli/debian/postinst
@@ -2,6 +2,6 @@
 
 set -e
 
-cp /usr/share/doc/nipap-cli/bash_complete /etc/bash_completion.d/nipap
+install -D /usr/share/doc/nipap-cli/bash_complete /etc/bash_completion.d/nipap
 
 #DEBHELPER#


### PR DESCRIPTION
Use GNU coreutils `install` to install bash completion script, to make sure that the directory exists before copying the file.

Fixes #1248, #1241