### PR TITLE
Rest API feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
     - if [ "$INSTALL" == "apt" ]; then wget -O - https://spritelink.github.io/NIPAP/nipap.gpg.key | sudo apt-key add -; fi
     - if [ "$INSTALL" == "apt" ]; then sudo apt-get update -qq; fi
     # install dependencies for installing & running nipap
-    - if [ "$INSTALL" == "apt" ]; then sudo apt-get install -qq -y python-pysqlite2 python-psycopg2 python-ipy python3-ipy python-docutils python-tornado python-flask python-flask-xml-rpc python-flask-compress python-parsedatetime python-pylons python-tz python-dateutil python-psutil python-pyparsing; fi
+    - if [ "$INSTALL" == "apt" ]; then sudo apt-get install -qq -y python-pysqlite2 python-psycopg2 python-ipy python3-ipy python-docutils python-tornado python-flask python-flask-xml-rpc python-flask-restful python-requests python-flask-compress python-parsedatetime python-pylons python-tz python-dateutil python-psutil python-pyparsing; fi
     # if we are testing the upgrade, first install NIPAP packages from official repo
     - if [ "$INSTALL" == "apt" ] && [ "$UPGRADE" == "true" ]; then sudo apt-get install -qq nipapd nipap-www nipap-cli; fi
     # bump version so that we know we are upgrading beyond what is installed
@@ -105,6 +105,7 @@ script:
     # if upgrade, verify data loaded before upgrade looks correct post upgrade
     - if [ "$INSTALL" == "apt" ] && [ "$UPGRADE" == "true" ]; then nosetests upgrade-after.py; fi
     - nosetests xmlrpc.py
+    - nosetests test_rest.py
     - nosetests nipaptest.py
     - nosetests test_cli.py
     - nosetests nipap-ro.py

--- a/nipap-cli/debian/postinst
+++ b/nipap-cli/debian/postinst
@@ -2,6 +2,6 @@
 
 set -e
 
-cp /usr/share/doc/nipap-cli/bash_complete /etc/bash_completion.d/nipap
+install -D /usr/share/doc/nipap-cli/bash_complete /etc/bash_completion.d/nipap
 
 #DEBHELPER#

--- a/nipap/debian/control
+++ b/nipap/debian/control
@@ -17,7 +17,7 @@ Description: Neat IP Address Planner
 
 Package: nipapd
 Architecture: all
-Depends: debconf, nipap-common, python (>= 2.7), ${misc:Depends}, python-psycopg2, python-flask, python-flask-xml-rpc, python-flask-compress, python-tornado, python-parsedatetime, python-tz, python-dateutil, python-psutil, python-pyparsing
+Depends: debconf, nipap-common, python (>= 2.7), ${misc:Depends}, python-psycopg2, python-flask, python-flask-xml-rpc, python-flask-restful, python-flask-compress, python-tornado, python-parsedatetime, python-tz, python-dateutil, python-psutil, python-pyparsing
 Description: Neat IP Address Planner XML-RPC daemon
  The Neat IP Address Planner, NIPAP, is a system built for efficiently managing
  large amounts of IP addresses. This is the XML-RPC daemon.

--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -49,7 +49,7 @@
 listen = {{LISTEN_ADDRESS}}      ; IP address to listen on.
 # The default is to listen to 127.0.0.1. Use 0.0.0.0 to listen on all addresses
 # (change requires restart).
-port = {{LISTEN_PORT}}          ; XML-RPC listen port (change requires restart)
+port = {{LISTEN_PORT}}          ; API listen port (change requires restart)
 
 foreground = false              ; run in foreground, won't work with init script
 debug = false                   ; enable debug logging

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -1,0 +1,221 @@
+""" NIPAP REST
+    ==============
+    This module contains the actual functions presented over the REST API. All 
+    functions are quite thin and mostly wrap around the functionalty provided by
+    the backend module.
+"""
+
+import datetime
+import logging
+import time
+import pytz
+import json
+from functools import wraps
+from flask import Flask, request, Response, got_request_exception, jsonify
+from flask_restful import Resource, Api, abort
+
+from backend import Nipap, NipapError
+import nipap
+from authlib import AuthFactory, AuthError
+
+
+def setup(app):
+    api = Api(app, prefix="/rest/v1")
+    api.add_resource(NipapPrefixRest, "/prefixes")
+
+    return app  
+
+
+def combine_request_args():
+        args = {} 
+
+        request_authoritative_source = request.headers.get('NIPAP-Authoritative-Source')
+        request_nipap_username = request.headers.get('NIPAP-Username')
+        request_nipap_fullname = request.headers.get('NIPAP-Full-Name')
+
+        request_body = request.json
+        request_queries = request.args.to_dict()
+
+        if request_authoritative_source:
+            authoritative_source = { 'auth':{'authoritative_source': request_authoritative_source}}
+            args.update(authoritative_source)
+
+            if request_nipap_username:
+                args['auth'].update({'username': request_nipap_username})
+            
+            if request_nipap_fullname:
+                args['auth'].update({'full_name': request_nipap_fullname})
+        
+        if request_queries and request.method == 'POST':
+            temp_args = {}
+            if request_queries.get("fromPoolName"):
+                from_pool_name = {"from-pool": {"name": str(request_queries.get("fromPoolName"))}}
+                family = {"family": request_queries.get("family")}
+                prefix_length = {"prefix_length": int(request_queries.get("prefixLength"))}
+                temp_args.update(from_pool_name)
+                temp_args.update(family)
+                temp_args.update(prefix_length)
+            else:
+                from_prefix = {"from-prefix": [request_queries.get("fromPrefix")]}
+                prefix_length = {"prefix_length": request_queries.get("prefixLength")}
+                temp_args.update(from_prefix)
+                temp_args.update(prefix_length)
+
+            args.update({'args': temp_args})
+
+        elif request_queries and not request.method == 'POST':
+            args.update({'prefix': request_queries})
+
+        if request_body:
+            args.update(request_body)
+        
+        return args
+
+
+def _mangle_prefix(res):
+    """ Mangle prefix result
+    """
+    # fugly cast from large numbers to string to deal with XML-RPC
+    res['total_addresses'] = unicode(res['total_addresses'])
+    res['used_addresses'] = unicode(res['used_addresses'])
+    res['free_addresses'] = unicode(res['free_addresses'])
+
+    # postgres has notion of infinite while datetime hasn't, if expires
+    # is equal to the max datetime we assume it is infinity and instead
+    # represent that as None
+    if res['expires'].tzinfo is None:
+        res['expires'] = pytz.utc.localize(res['expires'])
+    if res['expires'] == pytz.utc.localize(datetime.datetime.max):
+        res['expires'] = None
+    
+    return res
+
+
+def authenticate():
+    """ Sends a 401 response that enables basic auth
+    """
+    return Response(
+        'Could not verify your access level for that URL.\n'
+        'You have to login with proper credentials', 401,
+        {'WWW-Authenticate': 'Basic realm="Login Required"'})
+
+
+def requires_auth(f):
+    """ Class decorator for REST functions that requires auth
+    """
+    @wraps(f)
+
+    def decorated(self, *args, **kwargs):
+        """
+        """
+        # small hack 
+        args = args +(combine_request_args(),)
+
+        # Fetch auth options from args
+        auth_options = {}
+        nipap_args = {}
+
+        # validate function arguments
+        if len(args) == 1:
+            nipap_args = args[0]
+        else:
+            self.logger.debug("Malformed request: got %d parameters" % len(args))
+            abort(401, error={"code": 401, "message": "Malformed request: got %d parameters" % len(args)})
+    
+        if type(nipap_args) != dict:
+            self.logger.debug("Function argument is not struct")
+            abort(401, error={"code": 401, "message": "Function argument is not struct"})
+
+        # fetch auth options
+        try:
+            auth_options = nipap_args['auth']
+            if type(auth_options) is not dict:
+                raise ValueError()
+        except (KeyError, ValueError):
+            self.logger.debug("Missing/invalid authentication options in request.")
+            abort(401, error={"code": 401, "message": "Missing/invalid authentication options in request."})
+
+        # fetch authoritative source
+        try:
+            auth_source = auth_options['authoritative_source']
+        except KeyError:
+            self.logger.debug("Missing authoritative source in auth options.")
+            abort(401, error={"code": 401, "message": "Missing authoritative source in auth options."})
+
+        if not request.authorization:
+            return authenticate()
+
+        # init AuthFacory()
+        af = AuthFactory()
+        auth = af.get_auth(
+            request.authorization.username,
+            request.authorization.password,
+            auth_source, auth_options or {})
+
+        # authenticated?
+        if not auth.authenticate():
+            self.logger.debug("Incorrect username or password.")
+            abort(401, error={"code": 401, "message": "Incorrect username or password"})
+
+        # Replace auth options in API call arguments with auth object
+        new_args = dict(args[0])
+        new_args['auth'] = auth
+
+        return f(self, *(new_args,), **kwargs)
+
+    return decorated
+
+
+
+class NipapPrefixRest(Resource):
+
+    def __init__(self):
+        self.nip = Nipap()
+        self.logger = logging.getLogger()
+
+
+    @requires_auth
+    def get(self, args):
+        try:
+            result = self.nip.list_prefix(
+                args.get('auth'), args.get('prefix') or {})
+
+            # mangle result
+            for prefix in result:
+                prefix = _mangle_prefix(prefix)
+
+            result = jsonify(result)
+            return result
+        except (AuthError, NipapError) as exc:
+            self.logger.debug(unicode(exc))
+            abort(500, error={"code": 500, "message": exc})
+
+
+    @requires_auth
+    def post(self, args):
+        try:
+            result = self.nip.add_prefix(
+                args.get('auth'), args.get('attr'), args.get('args'))
+           
+            result["free_addresses"] = str(result.get("free_addresses"))
+            result["total_addresses"] = str(result.get("total_addresses"))
+            result["added"] = str(result.get("added"))
+            result["expires"] = str(result.get("expires"))
+            result["last_modified"] = str(result.get("last_modified"))
+            result["used_addresses"] = str(result.get("used_addresses"))
+            result = jsonify(result)
+            return result
+        except (AuthError, NipapError) as exc:
+            self.logger.debug(unicode(exc))
+            abort(500, error={"code": 500, "message": str(exc)})
+
+
+    @requires_auth
+    def delete(self, args):
+        try:
+            # as of now remove_prefix doesn't return any values
+            self.nip.remove_prefix(args.get('auth'), args.get('prefix'))
+            return jsonify(args.get('prefix'))
+        except (AuthError, NipapError) as exc:
+            self.logger.debug(unicode(exc))
+            abort(500, error={"code": 500, "message": exc})

--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -13,10 +13,6 @@ from functools import wraps
 from flask import Flask
 from flask import request, Response
 from flaskext.xmlrpc import XMLRPCHandler, Fault
-try:
-    from flask_compress import Compress
-except ImportError:
-    from flask.ext.compress import Compress
 
 from nipapconfig import NipapConfig
 from backend import Nipap, NipapError
@@ -24,10 +20,7 @@ import nipap
 from authlib import AuthFactory, AuthError
 
 
-def setup():
-    app = Flask('nipap.xmlrpc')
-    Compress(app)
-
+def setup(app):
     handler = XMLRPCHandler('XMLRPC')
     handler.connect(app, '/RPC2')
     handler.connect(app, '/XMLRPC')

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -23,6 +23,12 @@ import psutil
 import signal
 import atexit
 
+from flask import Flask
+try:
+    from flask_compress import Compress
+except ImportError:
+    from flask.ext.compress import Compress
+
 def exit_cleanup():
     """ Cleanup stuff on program exit
     """
@@ -216,8 +222,15 @@ if __name__ == '__main__':
         lf.write('%d\n' % os.getpid())
         lf.flush()
 
+    # flask app setups
+    app = Flask(__name__)
+    Compress(app)
+    
+    import nipap.rest
+    rest = nipap.rest.setup(app)
+
     import nipap.xmlrpc
-    nipapxml = nipap.xmlrpc.setup()
+    nipapxml = nipap.xmlrpc.setup(app)
 
     if not cfg.getboolean('nipapd', 'foreground'):
         # If we are not running in the foreground, remove current handlers which
@@ -230,12 +243,14 @@ if __name__ == '__main__':
     if cfg.getboolean('nipapd', 'debug'):
         logger.setLevel(logging.DEBUG)
         nipapxml.logger.setLevel(logging.DEBUG)
+        rest.logger.setLevel(logging.DEBUG)
 
     if cfg.getboolean('nipapd', 'syslog'):
         log_syslog = logging.handlers.SysLogHandler(address = '/dev/log')
         log_syslog.setFormatter(logging.Formatter("%(levelname)-8s %(message)s"))
         logger.addHandler(log_syslog)
         nipapxml.logger.addHandler(log_syslog)
+        rest.logger.addHandler(log_syslog)
 
     if cfg.get('nipapd', 'listen') is None or cfg.get('nipapd', 'listen') == '':
         sockets = bind_sockets(cfg.get('nipapd', 'port'))
@@ -265,7 +280,7 @@ if __name__ == '__main__':
         # default is to fork as many processes as there are cores
         tornado.process.fork_processes(num_forks)
 
-    http_server = HTTPServer(WSGIContainer(nipapxml))
+    http_server = HTTPServer(WSGIContainer(app))
     http_server.add_sockets(sockets)
 
     # start Tornado

--- a/nipap/requirements.txt
+++ b/nipap/requirements.txt
@@ -1,6 +1,8 @@
 Flask==1.1.2
 Flask-Compress==1.9.0
 Flask-XML-RPC==0.1.2
+Flask-RESTful==0.3.8
+requests==2.25.1
 IPy==1.01
 Jinja2==2.11.3
 MarkupSafe==1.1.1

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python
+# vim: et :
+
+#
+# All of the tests in this test suite runs directly against the REST API
+# interfaces of NIPAP to check return data and so forth. 
+#
+
+import logging
+import unittest
+import sys
+sys.path.append('../nipap/')
+
+from nipap.backend import Nipap
+from nipap.authlib import SqliteAuth
+from nipap.nipapconfig import NipapConfig
+
+import requests
+import json
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+log_format = "%(levelname)-8s %(message)s"
+
+
+class NipapRestTest(unittest.TestCase):
+    """ Tests the NIPAP REST API
+
+        We presume the database is empty
+    """
+    maxDiff = None
+
+    logger = None
+    cfg = None
+    nipap = None
+
+    server_url = "http://unittest:gottatest@127.0.0.1:1337/rest/v1/prefixes"
+    headers = {"NIPAP-Authoritative-Source": "nipap", "NIPAP-Username": "unittest", "NIPAP-Full-Name": "unit tester"}
+
+    def setUp(self):
+        # logging
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        # NIPAP
+        self.cfg = NipapConfig('/etc/nipap/nipap.conf')
+        self.nipap = Nipap()
+
+        # create dummy auth object
+        # As the authentication is performed before the query hits the Nipap
+        # class, it does not matter what user we use here
+        self.auth = SqliteAuth('local', 'unittest', 'unittest', 'unittest')
+        self.auth.authenticated_as = 'unittest'
+        self.auth.full_name = 'Unit test'
+
+        # have to delete hosts before we can delete the rest
+        self.nipap._execute("DELETE FROM ip_net_plan WHERE masklen(prefix) = 32")
+        # the rest
+        self.nipap._execute("DELETE FROM ip_net_plan")
+        # delete all except for the default VRF with id 0
+        self.nipap._execute("DELETE FROM ip_net_vrf WHERE id > 0")
+        # set default info for VRF 0
+        self.nipap._execute("UPDATE ip_net_vrf SET name = 'default', description = 'The default VRF, typically the Internet.' WHERE id = 0")
+        self.nipap._execute("DELETE FROM ip_net_pool")
+        self.nipap._execute("DELETE FROM ip_net_asn")
+
+    
+    def _mangle_prefix_result(self, res):
+        """ Mangle prefix result for easier testing
+
+            We can never predict the values of things like the ID (okay, that
+            one is actually kind of doable) or the added and last_modified
+            timestamp. This function will make sure the values are present but
+            then strip them to make it easier to test against an expected
+            result.
+
+            All testing of statistics is done in nipaptest.py so we strip that
+            from the result here to make things simple.
+        """
+
+        if isinstance(res, list):
+            # res from list_prefix
+            for p in res:
+                self.assertIn('added', p)
+                self.assertIn('last_modified', p)
+                self.assertIn('total_addresses', p)
+                self.assertIn('used_addresses', p)
+                self.assertIn('free_addresses', p)
+                self.assertIn('expires', p)
+                del(p['added'])
+                del(p['last_modified'])
+                del(p['total_addresses'])
+                del(p['used_addresses'])
+                del(p['free_addresses'])
+                del(p['expires'])
+
+        elif isinstance(res, dict) and 'result' in res:
+            # res from smart search
+            for p in res['result']:
+                self.assertIn('added', p)
+                self.assertIn('last_modified', p)
+                self.assertIn('total_addresses', p)
+                self.assertIn('used_addresses', p)
+                self.assertIn('free_addresses', p)
+                self.assertIn('expires', p)
+                del(p['added'])
+                del(p['last_modified'])
+                del(p['total_addresses'])
+                del(p['used_addresses'])
+                del(p['free_addresses'])
+                del(res['expires'])
+
+        if isinstance(res, dict):
+            # just one single prefix
+            self.assertIn('added', res)
+            self.assertIn('last_modified', res)
+            self.assertIn('total_addresses', res)
+            self.assertIn('used_addresses', res)
+            self.assertIn('free_addresses', res)
+            self.assertIn('expires', res)
+            del(res['added'])
+            del(res['last_modified'])
+            del(res['total_addresses'])
+            del(res['used_addresses'])
+            del(res['free_addresses'])
+            del(res['expires'])
+
+        return res        
+
+
+    def _convert_list_of_unicode_to_str(self, list_of_items):
+        """ Converts list of unicode values to string
+            
+            This helper function converts keys and values in unicode to string for a list containing nested dictionaries.
+            
+            When converting JSON respons back to Python dict the keys and values are 
+            added as unicode. This helper function handles the problem, but all types get replaced to strings. Is used for assertEqual.
+        """
+        result = []
+        for item in list_of_items:
+            item = dict([(str(k), str(v)) for k, v in item.items()])
+            result.append(item)
+
+        return result
+
+
+    def test_prefix_add(self):
+        """ Add a prefix and list
+        """
+
+        # check that some error / sanity checking is there
+        attr = {'attr':{}}
+
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        self.assertRegexpMatches(text,"specify 'prefix' or 'from-prefix' or 'from-pool'")
+
+        attr['attr']['prefix'] = '1.3.3.0/24'
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        self.assertRegexpMatches(text, "Either description or node must be specified.")
+
+        attr['attr']['description'] = 'test prefix'
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        self.assertRegexpMatches(text, "Unknown prefix type")
+
+        attr['attr']['type'] = 'assignment'
+        attr['attr']['order_id'] = 'test'
+
+        # add 1.3.3.0/24
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+        attr['attr']['id'] = result['id']
+        self.assertGreater(attr['attr']['id'], 0)
+
+        # what we expect the above prefix to look like
+        expected = {
+                'alarm_priority': None,
+                'authoritative_source': 'nipap',
+                'avps': {},
+                'comment': None,
+                'country': None,
+                'description': 'test prefix',
+                'display_prefix': '1.3.3.0/24',
+                'external_key': None,
+                'family': 4,
+                'id': int(attr['attr']['id']),
+                'indent': 0,
+                'inherited_tags': [],
+                'monitor': None,
+                'node': None,
+                'order_id': 'test',
+                'customer_id': None,
+                'pool_name': None,
+                'pool_id': None,
+                'tags':[],
+                'status': 'assigned',
+                'vrf_rt': None,
+                'vrf_id': 0,
+                'vrf_name': 'default',
+                'vlan': None
+            }
+
+        expected = dict([(str(k), str(v)) for k, v in expected.items()])
+        expected.update(attr['attr'])
+        
+        # list of prefixes through GET request
+        parameters = {'order_id': 'test'}
+        list_prefix_request = request = requests.get(self.server_url, headers=self.headers, params=parameters)
+        list_prefix = json.loads(list_prefix_request.text)
+        #print(list_prefix)
+        #list_prefix = dict([(str(k), str(v)) for k, v in list_prefix.items()])
+        list_prefix = self._convert_list_of_unicode_to_str(list_prefix)
+        print(list_prefix)
+        
+        self.assertEqual(
+                self._mangle_prefix_result(list_prefix),
+                [expected])
+
+        attr = {'attr':{}}
+        attr['attr']['description'] = 'test for from-prefix 1.3.3.0/24'
+        attr['attr']['type'] = 'host'
+        attr['attr']['order_id'] = 'test'
+
+        parameters = {'fromPrefix': '1.3.3.0/24', 'prefixLength': 32}
+
+        # add a host in 1.3.3.0/24
+        request = requests.post(self.server_url, headers=self.headers, json = attr, params = parameters)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+
+        # copy expected from 1.3.3.0/24 since we expect most things to look the
+        # same for the new prefix (1.3.3.1/32) from 1.3.3.0/24
+        expected_host = expected.copy()
+        expected_host.update(attr['attr'])
+        print(expected_host)
+        expected_host['id'] = result['id']
+        expected_host['prefix'] = '1.3.3.1/32'
+        expected_host['display_prefix'] = '1.3.3.1/24'
+        expected_host['indent'] = 1
+
+        # build list of expected
+        expected_list = []
+        expected_list.append(expected)
+        expected_list.append(expected_host)
+        expected_list = self._convert_list_of_unicode_to_str(expected_list)
+
+        # add another prefix, try with vrf_id = None
+        attr['attr']['vrf_id'] = None
+        request = requests.post(self.server_url, headers=self.headers, json = attr, params = parameters)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+        # update expected list
+        expected_host2 = expected_host.copy()
+        expected_host2['id'] = result['id']
+        expected_host2['prefix'] = '1.3.3.2/32'
+        expected_host2['display_prefix'] = '1.3.3.2/24'
+        expected_list.append(expected_host2)
+        expected_list = self._convert_list_of_unicode_to_str(expected_list)
+
+        # add another prefix, this time completely without VRF info
+        del(attr['attr']['vrf_id'])
+        request = requests.post(self.server_url, headers=self.headers, json = attr, params = parameters)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+        # update expected list
+        expected_host3 = expected_host.copy()
+        expected_host3['id'] = result['id']
+        expected_host3['prefix'] = '1.3.3.3/32'
+        expected_host3['display_prefix'] = '1.3.3.3/24'
+        expected_list.append(expected_host3)
+        expected_list = self._convert_list_of_unicode_to_str(expected_list)
+
+        # list of prefixes through GET request
+        parameters = {'order_id': 'test'}
+        list_prefix_request = request = requests.get(self.server_url, headers=self.headers, params=parameters)
+        list_prefix = json.loads(list_prefix_request.text)
+        list_prefix = self._convert_list_of_unicode_to_str(list_prefix)
+
+        mangled_result = self._mangle_prefix_result(list_prefix)
+
+        # make sure the result looks like we expect it too! :D
+        self.assertEqual(
+                mangled_result,
+                expected_list)
+
+    def test_prefix_remove(self):
+        """ Removes a prefix
+        """
+
+        # add 1.3.3.4/24
+        attr = {'attr':{}}
+        attr['attr']['prefix'] = '1.3.4.0/24'
+        attr['attr']['description'] = 'test delete prefix'
+        attr['attr']['type'] = 'assignment'
+        attr['attr']['order_id'] = 'test'
+
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+
+        prefix_id = result['id']
+
+        # delete prefix
+        parameters = {'id': prefix_id}
+        request = requests.delete(self.server_url, headers=self.headers, params=parameters)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+
+        expected = {
+                'prefix': '1.3.4.0/24',
+                'vrf_id': '0',
+            }
+
+        self.assertEqual(result, expected)
+
+
+
+if __name__ == '__main__':
+
+    # set up logging
+    log = logging.getLogger()
+    logging.basicConfig()
+    log.setLevel(logging.INFO)
+
+    if sys.version_info >= (2,7):
+        unittest.main(verbosity=2)
+    else:
+        unittest.main()
+        


### PR DESCRIPTION
### Change in this Pull request

Adding some REST functionality to NIPAP.

The change will make it possible to do XMLRPC and REST requests to the same IP and Port.
BUT, as of now, all functions aren't set up in in the new functionality.

The authentication used in xmlrpc.py is used in rest.py, but to be able to use decorators correctly i had to recieve the request first and then send my args to a helper function where changes to args are made, see below:

```
@requires_auth
    def list_prefixes(self, args):
        return args

    
    def get(self):
        combined_args = self.combine_request_args(False)
        args = self.list_prefixes(combined_args)

        try:
            result = self.nip.list_prefix(args.get('auth'), args.get('prefix') or {})
            # mangle result
            for prefix in result:
                prefix = _mangle_prefix(prefix)

            result = jsonify(result)
            return result
        except (AuthError, NipapError) as exc:
            self.logger.debug(unicode(exc))
            abort(500, error={"code": 500, "message": exc})
```

I'm not very proud of the solution but it works, without doing major changes to the "requires_auth" decorator.

### Limitations
Per this pull request only the following NIPAP functions are provided by the REST API:

- list_prefix
- add_prefix
- remove_prefix

The above are done through GET, POST and DELETE to the endpoint /rest/v1/prefixes

PUT needs to be added for editing prefixes, it's not with this PR.

Further development should be made to add the other functionalities that are in the XMLRPC API.