### PR TITLE
nipapd: improve smart_search_vrf search

### DIFF
--- a/nipap/nipap/xmlrpc.py
+++ b/nipap/nipap/xmlrpc.py
@@ -342,8 +342,6 @@ class NipapXMLRPC:
             Returns a struct containing search result, interpretation of the
             search string and the search options used.
         """
-        import time
-        time.sleep(1)
         try:
             res = self.nip.smart_search_vrf(args.get('auth'),
                     args.get('query_string'), args.get('search_options', {}),


### PR DESCRIPTION
When NIPAP page rendering was slow we found that removing this sleep
wastly improved performance. It was introduced with commit 1da02003
(www: Improvements of VRF list smart search).