### PR TITLE
The Expires date field was always empty in the UI because the datepic…

### DIFF
--- a/nipap-www/nipapwww/public/controllers.js
+++ b/nipap-www/nipapwww/public/controllers.js
@@ -567,6 +567,10 @@ nipapAppControllers.controller('PrefixEditController', function ($scope, $routeP
 
 				$scope.prefix = pref;
 
+				// The datepicker expects a Javascript Date object to be able to show the date
+				if($scope.prefix.expires != null && $scope.prefix.expires.length > 0)
+					$scope.prefix.expires = new Date($scope.prefix.expires);
+
 				// Fetch prefix's VRF
 				$http.post('/xhr/smart_search_vrf',
 					JSON.stringify({


### PR DESCRIPTION
The UI bootstraP datepicker control expects that the date in the model is a Javascript Date object so it can handle it correctly.
If it is a string it cannot display the date.