### PR TITLE
REST API case-insensitive search - fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           junit4 \
           python-docutils \
           python-nose \
+          python-requests \
+          python3-requests \
           python-setuptools \
           python3-setuptools \
           python-wheel \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,4 +150,5 @@ jobs:
         nosetests tests/nipaptest.py
         nosetests tests/test_cli.py
         nosetests tests/nipap-ro.py
+        nosetests tests/test_rest.py
         make -C jnipap test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
       run: nosetests tests/upgrade-after.py
 
     - name: "Run test suite"
+      env:
+        REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       run: |
         nosetests tests/xmlrpc.py
         nosetests tests/nipaptest.py

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -168,19 +168,20 @@ def requires_auth(f):
 
     return decorated
 
+
 def get_query_for_field(field, search_value):
 
     operator = "="
-    
+
     fields_supporting_case_insesitive_search = ['description','comment','node','country','customer_id','external_key','authoritative_source','order_id']
     if field in fields_supporting_case_insesitive_search:
         operator = "~*"
         search_value = '^' + search_value + '$'
 
-    return { 
+    return {
             'operator': operator,
             'val1': field,
-            'val2': search_value 
+            'val2': search_value
         }
 
 
@@ -195,9 +196,8 @@ class NipapPrefixRest(Resource):
     def get(self, args):
 
         query = args.get('prefix')
-        if query != None:
+        if query is not None:
             try:
-            
                 field = query.items()[0][0]
                 search_value = query.items()[0][1]
                 search_query = get_query_for_field(field, search_value)

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -174,7 +174,7 @@ class NipapPrefixRest(Resource):
 
     def __init__(self):
         self.nip = Nipap()
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(self.__class__.__name__)
 
 
     @requires_auth

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -191,7 +191,7 @@ class NipapPrefixRest(Resource):
             return result
         except (AuthError, NipapError) as exc:
             self.logger.debug(unicode(exc))
-            abort(500, error={"code": 500, "message": exc})
+            abort(500, error={"code": 500, "message": str(exc)})
 
 
     @requires_auth
@@ -221,4 +221,4 @@ class NipapPrefixRest(Resource):
             return jsonify(args.get('prefix'))
         except (AuthError, NipapError) as exc:
             self.logger.debug(unicode(exc))
-            abort(500, error={"code": 500, "message": exc})
+            abort(500, error={"code": 500, "message": str(exc)})

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -168,6 +168,20 @@ def requires_auth(f):
 
     return decorated
 
+def get_query_for_field(field, search_value):
+
+    operator = "="
+    
+    fields_supporting_case_insesitive_search = ['description','comment','node','country','customer_id','external_key','authoritative_source','order_id']
+    if field in fields_supporting_case_insesitive_search:
+        operator = "~*"
+        search_value = '^' + search_value + '$'
+
+    return { 
+            'operator': operator,
+            'val1': field,
+            'val2': search_value 
+        }
 
 
 class NipapPrefixRest(Resource):
@@ -179,26 +193,55 @@ class NipapPrefixRest(Resource):
 
     @requires_auth
     def get(self, args):
-        try:
-            result = self.nip.list_prefix(
-                args.get('auth'), args.get('prefix') or {})
 
-            # mangle result
-            for prefix in result:
-                prefix = _mangle_prefix(prefix)
+        query = args.get('prefix')
+        if query != None:
+            try:
+            
+                field = query.items()[0][0]
+                search_value = query.items()[0][1]
+                search_query = get_query_for_field(field, search_value)
 
-            result = jsonify(result)
-            return result
-        except (AuthError, NipapError) as exc:
-            self.logger.debug(unicode(exc))
-            abort(500, error={"code": 500, "message": str(exc)})
-        except HTTPError as http_err:
-            self.logger.debug(unicode(http_err))
-            abort(500, error={"code": 500, "message": str(http_err)})
-        except Exception as err:
-            self.logger.debug(unicode(err))
-            abort(500, error={"code": 500, "message": str(err)})
+                result = self.nip.search_prefix(args.get('auth'), search_query)
 
+                # mangle result
+                for prefix in result['result']:
+                    prefix = _mangle_prefix(prefix)
+
+                result = jsonify(result['result'])
+                return result
+
+            except (AuthError, NipapError, Exception) as exc:
+                self.logger.debug(exc)
+                abort(500, error={"code": 500, "message": str(exc)})
+            except HTTPError as http_err:
+                self.logger.debug(unicode(http_err))
+                abort(500, error={"code": 500, "message": str(http_err)})
+            except Exception as err:
+                self.logger.debug(unicode(err))
+                abort(500, error={"code": 500, "message": str(err)})
+
+        else:
+            try:
+                result = self.nip.list_prefix(
+                    args.get('auth'), {})
+
+                # mangle result
+                for prefix in result:
+                    prefix = _mangle_prefix(prefix)
+
+                result = jsonify(result)
+                return result
+
+            except (AuthError, NipapError, Exception) as exc:
+                self.logger.debug(exc)
+                abort(500, error={"code": 500, "message": str(exc)})
+            except HTTPError as http_err:
+                self.logger.debug(unicode(http_err))
+                abort(500, error={"code": 500, "message": str(http_err)})
+            except Exception as err:
+                self.logger.debug(unicode(err))
+                abort(500, error={"code": 500, "message": str(err)})
 
     @requires_auth
     def post(self, args):

--- a/nipap/nipap/rest.py
+++ b/nipap/nipap/rest.py
@@ -17,7 +17,7 @@ from flask_restful import Resource, Api, abort
 from backend import Nipap, NipapError
 import nipap
 from authlib import AuthFactory, AuthError
-
+from requests.models import HTTPError
 
 def setup(app):
     api = Api(app, prefix="/rest/v1")
@@ -192,6 +192,12 @@ class NipapPrefixRest(Resource):
         except (AuthError, NipapError) as exc:
             self.logger.debug(unicode(exc))
             abort(500, error={"code": 500, "message": str(exc)})
+        except HTTPError as http_err:
+            self.logger.debug(unicode(http_err))
+            abort(500, error={"code": 500, "message": str(http_err)})
+        except Exception as err:
+            self.logger.debug(unicode(err))
+            abort(500, error={"code": 500, "message": str(err)})
 
 
     @requires_auth
@@ -211,6 +217,12 @@ class NipapPrefixRest(Resource):
         except (AuthError, NipapError) as exc:
             self.logger.debug(unicode(exc))
             abort(500, error={"code": 500, "message": str(exc)})
+        except HTTPError as http_err:
+            self.logger.debug(unicode(http_err))
+            abort(500, error={"code": 500, "message": str(http_err)})
+        except Exception as err:
+            self.logger.debug(unicode(err))
+            abort(500, error={"code": 500, "message": str(err)})
 
 
     @requires_auth
@@ -222,3 +234,9 @@ class NipapPrefixRest(Resource):
         except (AuthError, NipapError) as exc:
             self.logger.debug(unicode(exc))
             abort(500, error={"code": 500, "message": str(exc)})
+        except HTTPError as http_err:
+            self.logger.debug(unicode(http_err))
+            abort(500, error={"code": 500, "message": str(http_err)})
+        except Exception as err:
+            self.logger.debug(unicode(err))
+            abort(500, error={"code": 500, "message": str(err)})

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: et sw=4 sts=4 :
 
 import fcntl

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -343,14 +343,17 @@ class NipapRestTest(unittest.TestCase):
 
 
     def test_prefix_search_case_sensitive(self):
-        """ Add a prefix and search for it case sensitive 
+        """ Add a prefix and search for it case sensitive
         """
+
+        add_orderId_value = 's-12345'
+        search_orderId_value = 's-12345'
 
         attr = {}
         attr['prefix'] = '1.3.5.0/24'
         attr['description'] = 'test prefix'
         attr['type'] = 'assignment'
-        attr['order_id'] = 's-12345'
+        attr['order_id'] = add_orderId_value
         prefix_id = self._add_prefix(attr)
         attr['id'] = prefix_id
         self.assertGreater(attr['id'], 0)
@@ -359,9 +362,8 @@ class NipapRestTest(unittest.TestCase):
         expected['display_prefix'] = '1.3.5.0/24'
         expected = dict([(str(k), str(v)) for k, v in expected.items()])
         expected.update(attr)
-        
-        # list of prefixes through GET request
-        parameters = {'order_id': 's-12345'}
+
+        parameters = {'order_id': search_orderId_value}
         get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
         result = json.loads(get_prefix_request.text)
         result = self._convert_list_of_unicode_to_str(result)
@@ -375,11 +377,14 @@ class NipapRestTest(unittest.TestCase):
         """ Add a prefix and search for it case insensitive 
         """
 
+        add_orderId_value = 's-12345'
+        search_orderId_value = 'S-12345'
+
         attr = {}
         attr['prefix'] = '1.3.6.0/24'
         attr['description'] = 'test prefix'
         attr['type'] = 'assignment'
-        attr['order_id'] = 's-12345'
+        attr['order_id'] = add_orderId_value
         prefix_id = self._add_prefix(attr)
         attr['id'] = prefix_id
         self.assertGreater(attr['id'], 0)
@@ -389,7 +394,7 @@ class NipapRestTest(unittest.TestCase):
         expected = dict([(str(k), str(v)) for k, v in expected.items()])
         expected.update(attr)
 
-        parameters = {'order_id': 'S-12345'}
+        parameters = {'order_id': search_orderId_value}
         get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
         result = json.loads(get_prefix_request.text)
         result = self._convert_list_of_unicode_to_str(result)
@@ -416,7 +421,7 @@ class NipapRestTest(unittest.TestCase):
         parameters = {'prefixeere': '1.3.8.0/24'}
         get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
 
-        self.assertTrue(get_prefix_request.text.__contains__('prefixee'))
+        self.assertTrue(get_prefix_request.text.__contains__('\'prefixeere\' unknown'))
 
 
 if __name__ == '__main__':

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -48,7 +48,7 @@ prefix_result_template = {
         'pool_name': None,
         'pool_id': None,
         'prefix_length': 24,
-        'tags':[],
+        'tags': [],
         'status': 'assigned',
         'vrf_rt': None,
         'vrf_id': 0,
@@ -218,7 +218,7 @@ class NipapRestTest(unittest.TestCase):
         result = dict([(str(k), str(v)) for k, v in result.items()])
         attr['id'] = result['id']
         self.assertGreater(attr['id'], 0)
-        
+
         # what we expect the above prefix to look like
         expected = prefix_result_template
         expected['id'] = int(attr['id'])
@@ -232,9 +232,7 @@ class NipapRestTest(unittest.TestCase):
         list_prefix = json.loads(list_prefix_request.text)
         list_prefix = self._convert_list_of_unicode_to_str(list_prefix)
 
-        self.assertEqual(
-                self._mangle_prefix_result(list_prefix),
-                [expected])
+        self.assertEqual(self._mangle_prefix_result(list_prefix), [expected])
 
         attr = {}
         attr['description'] = 'test for from-prefix 1.3.3.0/24'
@@ -263,7 +261,8 @@ class NipapRestTest(unittest.TestCase):
         # build list of expected
         expected_list = []
 
-        # updated the children for the first one because we are adding 3 new ones to it
+        # update the children for the first one because we are adding 
+        # 3 new ones to it
         expected['children'] = '3'
 
         expected_list.append(expected)
@@ -309,9 +308,7 @@ class NipapRestTest(unittest.TestCase):
         mangled_result = self._mangle_prefix_result(list_prefix)
 
         # make sure the result looks like we expect it too! :D
-        self.assertEqual(
-                mangled_result,
-                expected_list)
+        self.assertEqual(mangled_result, expected_list)
 
 
     def test_prefix_remove(self):
@@ -368,9 +365,7 @@ class NipapRestTest(unittest.TestCase):
         result = json.loads(get_prefix_request.text)
         result = self._convert_list_of_unicode_to_str(result)
         
-        self.assertEqual(
-                self._mangle_prefix_result(result),
-                [expected])
+        self.assertEqual(self._mangle_prefix_result(result), [expected])
 
 
     def test_prefix_search_case_insensitive(self):
@@ -399,9 +394,7 @@ class NipapRestTest(unittest.TestCase):
         result = json.loads(get_prefix_request.text)
         result = self._convert_list_of_unicode_to_str(result)
 
-        self.assertEqual(
-                    self._mangle_prefix_result(result),
-                    [expected])
+        self.assertEqual(self._mangle_prefix_result(result), [expected])
 
 
     def test_prefix_search_error_code(self):
@@ -410,9 +403,7 @@ class NipapRestTest(unittest.TestCase):
         parameters = {'prefixeere': '1.3.7.0/24'}
         get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
 
-        self.assertEqual(
-                    get_prefix_request.status_code,
-                    500)
+        self.assertEqual(get_prefix_request.status_code, 500)
 
 
     def test_prefix_search_error_message(self):

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -25,6 +25,37 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 log_format = "%(levelname)-8s %(message)s"
 
+prefix_result_template = {
+        'alarm_priority': None,
+        'authoritative_source': 'nipap',
+        'avps': {},
+        'children': 0,
+        'comment': None,
+        'country': None,
+        'description': 'test prefix',
+        'display': True,
+        'display_prefix': '1.3.1.0/24',
+        'external_key': None,
+        'family': 4,
+        'id': 0,
+        'indent': 0,
+        'inherited_tags': [],
+        'match': True,
+        'monitor': None,
+        'node': None,
+        'order_id': 'test',
+        'customer_id': None,
+        'pool_name': None,
+        'pool_id': None,
+        'prefix_length': 24,
+        'tags':[],
+        'status': 'assigned',
+        'vrf_rt': None,
+        'vrf_id': 0,
+        'vrf_name': 'default',
+        'vlan': None
+    }
+
 
 class NipapRestTest(unittest.TestCase):
     """ Tests the NIPAP REST API
@@ -110,7 +141,7 @@ class NipapRestTest(unittest.TestCase):
                 del(p['total_addresses'])
                 del(p['used_addresses'])
                 del(p['free_addresses'])
-                del(res['expires'])
+                del(p['expires'])
 
         if isinstance(res, dict):
             # just one single prefix
@@ -146,6 +177,15 @@ class NipapRestTest(unittest.TestCase):
         return result
 
 
+    def _add_prefix(self, attr):
+        request = requests.post(self.server_url, headers=self.headers, json = attr)
+        text = request.text
+        result = json.loads(text)
+        result = dict([(str(k), str(v)) for k, v in result.items()])
+
+        return result['id']
+
+
     def test_prefix_add(self):
         """ Add a prefix and list
         """
@@ -178,35 +218,11 @@ class NipapRestTest(unittest.TestCase):
         result = dict([(str(k), str(v)) for k, v in result.items()])
         attr['id'] = result['id']
         self.assertGreater(attr['id'], 0)
-
+        
         # what we expect the above prefix to look like
-        expected = {
-                'alarm_priority': None,
-                'authoritative_source': 'nipap',
-                'avps': {},
-                'comment': None,
-                'country': None,
-                'description': 'test prefix',
-                'display_prefix': '1.3.3.0/24',
-                'external_key': None,
-                'family': 4,
-                'id': int(attr['id']),
-                'indent': 0,
-                'inherited_tags': [],
-                'monitor': None,
-                'node': None,
-                'order_id': 'test',
-                'customer_id': None,
-                'pool_name': None,
-                'pool_id': None,
-                'tags':[],
-                'status': 'assigned',
-                'vrf_rt': None,
-                'vrf_id': 0,
-                'vrf_name': 'default',
-                'vlan': None
-            }
-
+        expected = prefix_result_template
+        expected['id'] = int(attr['id'])
+        expected['display_prefix'] = '1.3.3.0/24'
         expected = dict([(str(k), str(v)) for k, v in expected.items()])
         expected.update(attr)
 
@@ -241,9 +257,15 @@ class NipapRestTest(unittest.TestCase):
         expected_host['prefix'] = '1.3.3.1/32'
         expected_host['display_prefix'] = '1.3.3.1/24'
         expected_host['indent'] = 1
+        expected_host['prefix_length'] = '32'
+        expected_host['children'] = '0'
 
         # build list of expected
         expected_list = []
+
+        # updated the children for the first one because we are adding 3 new ones to it
+        expected['children'] = '3'
+
         expected_list.append(expected)
         expected_list.append(expected_host)
         expected_list = self._convert_list_of_unicode_to_str(expected_list)
@@ -259,6 +281,7 @@ class NipapRestTest(unittest.TestCase):
         expected_host2['id'] = result['id']
         expected_host2['prefix'] = '1.3.3.2/32'
         expected_host2['display_prefix'] = '1.3.3.2/24'
+        expected_host2['children'] = '0'
         expected_list.append(expected_host2)
         expected_list = self._convert_list_of_unicode_to_str(expected_list)
 
@@ -273,6 +296,7 @@ class NipapRestTest(unittest.TestCase):
         expected_host3['id'] = result['id']
         expected_host3['prefix'] = '1.3.3.3/32'
         expected_host3['display_prefix'] = '1.3.3.3/24'
+        expected_host3['children'] = '0'
         expected_list.append(expected_host3)
         expected_list = self._convert_list_of_unicode_to_str(expected_list)
 
@@ -289,6 +313,7 @@ class NipapRestTest(unittest.TestCase):
                 mangled_result,
                 expected_list)
 
+
     def test_prefix_remove(self):
         """ Removes a prefix
         """
@@ -299,13 +324,8 @@ class NipapRestTest(unittest.TestCase):
         attr['description'] = 'test delete prefix'
         attr['type'] = 'assignment'
         attr['order_id'] = 'test'
-
-        request = requests.post(self.server_url, headers=self.headers, json = attr)
-        text = request.text
-        result = json.loads(text)
-        result = dict([(str(k), str(v)) for k, v in result.items()])
-
-        prefix_id = result['id']
+        prefix_id = self._add_prefix(attr)
+        self.assertGreater(prefix_id, 0)
 
         # delete prefix
         parameters = {'id': prefix_id}
@@ -321,6 +341,82 @@ class NipapRestTest(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+
+    def test_prefix_search_case_sensitive(self):
+        """ Add a prefix and search for it case sensitive 
+        """
+
+        attr = {}
+        attr['prefix'] = '1.3.5.0/24'
+        attr['description'] = 'test prefix'
+        attr['type'] = 'assignment'
+        attr['order_id'] = 's-12345'
+        prefix_id = self._add_prefix(attr)
+        attr['id'] = prefix_id
+        self.assertGreater(attr['id'], 0)
+
+        expected = prefix_result_template
+        expected['display_prefix'] = '1.3.5.0/24'
+        expected = dict([(str(k), str(v)) for k, v in expected.items()])
+        expected.update(attr)
+        
+        # list of prefixes through GET request
+        parameters = {'order_id': 's-12345'}
+        get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
+        result = json.loads(get_prefix_request.text)
+        result = self._convert_list_of_unicode_to_str(result)
+        
+        self.assertEqual(
+                self._mangle_prefix_result(result),
+                [expected])
+
+
+    def test_prefix_search_case_insensitive(self):
+        """ Add a prefix and search for it case insensitive 
+        """
+
+        attr = {}
+        attr['prefix'] = '1.3.6.0/24'
+        attr['description'] = 'test prefix'
+        attr['type'] = 'assignment'
+        attr['order_id'] = 's-12345'
+        prefix_id = self._add_prefix(attr)
+        attr['id'] = prefix_id
+        self.assertGreater(attr['id'], 0)
+
+        expected = prefix_result_template
+        expected['display_prefix'] = '1.3.6.0/24'
+        expected = dict([(str(k), str(v)) for k, v in expected.items()])
+        expected.update(attr)
+
+        parameters = {'order_id': 'S-12345'}
+        get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
+        result = json.loads(get_prefix_request.text)
+        result = self._convert_list_of_unicode_to_str(result)
+
+        self.assertEqual(
+                    self._mangle_prefix_result(result),
+                    [expected])
+
+
+    def test_prefix_search_error_code(self):
+        """ Search for a prefix with incorrent fieldname, expect correct error code
+        """
+        parameters = {'prefixeere': '1.3.7.0/24'}
+        get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
+
+        self.assertEqual(
+                    get_prefix_request.status_code,
+                    500)
+
+
+    def test_prefix_search_error_message(self):
+        """ Search for a prefix with incorrent fieldname, expect correct error message
+        """
+        parameters = {'prefixeere': '1.3.8.0/24'}
+        get_prefix_request = requests.get(self.server_url, headers=self.headers, params=parameters)
+
+        self.assertTrue(get_prefix_request.text.__contains__('prefixee'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some fixes for #1310.

Added support for case insensitive search for string data values in the REST API + added some new tests for the REST API.
Also improved the error handling a bit so that the error message is returned correctly.