### PR TITLE
Remove accidental python2 hashbang

### DIFF
--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # vim: et sw=4 sts=4 :
 
 import fcntl


### PR DESCRIPTION
Clean up residual stuff from development. In fact setting this hashbang might be something we really want to do, but it needs to be thought through properly.