### PR TITLE
www: Fix KeyError in xhr.py

### DIFF
--- a/nipap-www/nipapwww/xhr.py
+++ b/nipap-www/nipapwww/xhr.py
@@ -117,7 +117,10 @@ def smart_search_vrf():
         # TODO: Reevaluate how to deal with different types of errors; soft
         # errors like query string parser errors and hard errors like lost
         # database.
-        del result['error']
+        try:
+            del result['error']
+        except KeyError:
+            pass
     except NipapError as e:
         return json.dumps({'error': 1,
                            'message': e.args,
@@ -256,7 +259,10 @@ def smart_search_pool():
         # TODO: Reevaluate how to deal with different types of errors; soft
         # errors like query string parser errors and hard errors like lost
         # database.
-        del result['error']
+        try:
+            del result['error']
+        except KeyError:
+            pass
     except NipapError as e:
         return json.dumps({'error': 1,
                            'message': e.args,
@@ -539,7 +545,10 @@ def smart_search_prefix():
         # TODO: Reevaluate how to deal with different types of errors; soft
         # errors like query string parser errors and hard errors like lost
         # database.
-        del result['error']
+        try:
+            del result['error']
+        except KeyError:
+            pass
     except NipapError as e:
         return json.dumps({'error': 1,
                            'message': e.args,


### PR DESCRIPTION
I got this exception for several versions now:
```
ERROR in app: Exception on /xhr/smart_search_prefix [POST]
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/nipap_www-0.31.1-py2.7.egg/nipapwww/auth.py", line 23, in wrapped_view
    return view(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/nipap_www-0.31.1-py2.7.egg/nipapwww/xhr.py", line 542, in smart_search_prefix
    search_options, extra_query)
KeyError: 'error'
```