### PR TITLE
Correct config variable for forks

### DIFF
--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -57,7 +57,7 @@ port = {{LISTEN_PORT}}          ; API listen port (change requires restart)
 foreground = false              ; run in foreground, won't work with init script
 debug = false                   ; enable debug logging
 
-fork = 0                        ; number of forks
+forks = 0                        ; number of forks
 # fork processes, mutually exclusive with foreground. 0 = automatically
 # determine number of forks (same as number of CPUs). -1 = no forking, >0 =
 # number of forks. Default is to automatically determine number of forks.


### PR DESCRIPTION
The config variable for configuring forks in the distributed nipap.conf was erroneous (!).

Fixes #1171 