### PR TITLE
UrlLib.Parse.Quote on password else it breaks on #

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -22,6 +22,8 @@ import sys
 
 import IPy
 
+from urllib.parse import quote
+
 import pynipap
 from pynipap import Pool, Prefix, Tag, VRF, NipapError
 from .command import Command
@@ -68,8 +70,12 @@ def setup_connection():
     try:
         con_params = {
             'protocol': determine_protocol(),
-            'username': os.getenv('NIPAP_USERNAME') or cfg.get('global', 'username'),
-            'password': os.getenv('NIPAP_PASSWORD') or cfg.get('global', 'password'),
+            'username': quote(
+                os.getenv('NIPAP_USERNAME') or cfg.get('global', 'username')
+            ),
+            'password': quote(
+                os.getenv('NIPAP_PASSWORD') or cfg.get('global', 'password')
+            ),
             'hostname': os.getenv('NIPAP_HOST') or cfg.get('global', 'hostname'),
             'port'    : os.getenv('NIPAP_PORT') or cfg.get('global', 'port')
         }


### PR DESCRIPTION
An annoying little bug when you use # in your password.

Using the password "MySecretPassword#2023"

```
$ nipap address list 123.123.123.124
Searching for prefixes in any VRF...
Traceback (most recent call last):
  File "/usr/lib/python3.11/http/client.py", line 889, in _get_hostport
    port = int(host[i+1:])
           ^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'MySecretPassword'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/nipap/bin/nipap", line 133, in <module>
    cmd.exe(cmd.arg, cmd.exe_options, args)
  File "/opt/nipap/lib/python3.11/site-packages/nipap_cli/nipap_cli.py", line 588, in list_prefix
    res = Prefix.smart_search(search_string, { 'parents_depth': -1,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/nipap/lib/python3.11/site-packages/pynipap.py", line 1091, in smart_search
    smart_result = xmlrpc.connection.smart_search_prefix(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1464, in __request
    response = self.__transport.request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1166, in request
    return self.single_request(host, handler, request_body, verbose)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1178, in single_request
    http_conn = self.send_request(host, handler, request_body, verbose)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1279, in send_request
    connection = self.make_connection(host)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/xmlrpc/client.py", line 1256, in make_connection
    self._connection = host, http.client.HTTPConnection(chost)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 851, in __init__
    (self.host, self.port) = self._get_hostport(host, port)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 894, in _get_hostport
    raise InvalidURL("nonnumeric port: '%s'" % host[i+1:])
http.client.InvalidURL: nonnumeric port:  'MySecretPassword'
```

This is fixed by using urrlib.parse.quote.