### PR TITLE
Drop Python 2 support in pynipap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
         sudo nipap/nipap-passwd add -u unittest -p gottatest -n unittest
         sudo nipap/nipap-passwd add -u readonly -p gottatest --readonly -n "Read-only user for running unit tests"
         # install pynipap
-        cd pynipap; sudo python setup.py install; cd ..
         cd pynipap; sudo python3 setup.py install; cd ..
         # install nipap-cli dependencies
         sudo -H pip3 install -r nipap-cli/requirements.txt

--- a/pynipap/debian/control
+++ b/pynipap/debian/control
@@ -3,24 +3,13 @@ Maintainer: Lukas Garberg <lukas@spritelink.net>
 Section: python
 Priority: optional
 Build-Depends: debhelper (>= 8), dh-python,
-               python (>= 2.7) | python2 (>= 2.7),
-               python3 (>= 3.1)
-X-Python-Version: >= 2.7
-X-Python3-Version: >= 3.1
+               python3 (>= 3.6)
+X-Python3-Version: >= 3.6
 Standards-Version: 4.4.0
-
-Package: python-pynipap
-Architecture: all
-Depends: ${misc:Depends}, python (>= 2.7) | python2 (>= 2.7)
-Breaks: ${python:Breaks}
-Description: Python module for accessing NIPAP
- This package contains a client library for NIPAP. It's function is similar to
- a simple ORM, which hides much of the complexity of working directly against
- the XML-RPC interface.
 
 Package: python3-pynipap
 Architecture: all
-Depends: ${misc:Depends}, python3 (>= 3.1)
+Depends: ${misc:Depends}, python3 (>= 3.6)
 Breaks: ${python3:Breaks}
 Description: Python 3 module for accessing NIPAP
  This package contains a client library for NIPAP. It's function is similar to

--- a/pynipap/debian/rules
+++ b/pynipap/debian/rules
@@ -3,4 +3,4 @@ export DH_VERBOSE=1
 export PYBUILD_NAME=pynipap
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild

--- a/pynipap/pynipap.py
+++ b/pynipap/pynipap.py
@@ -206,11 +206,7 @@
 """
 import sys
 import logging
-if sys.version_info[0] < 3:
-    import xmlrpclib
-    int = long
-else:
-    import xmlrpc.client as xmlrpclib
+import xmlrpc.client as xmlrpclib
 
 __version__		= "0.32.1"
 __author__		= "Kristian Larsson, Lukas Garberg"

--- a/pynipap/setup.py
+++ b/pynipap/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 import sys
@@ -26,7 +26,6 @@ setup(
             'License :: OSI Approved :: MIT License',
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware'
             ]


### PR DESCRIPTION
As all NIPAP components now are Python 3, let's finally drop Python 2 support for pynipap to simplify project maintenance.