### PR TITLE
Correct import path for init_tracing

### DIFF
--- a/nipap-www/nipapwww/__init__.py
+++ b/nipap-www/nipapwww/__init__.py
@@ -41,9 +41,9 @@ def create_app(test_config=None):
     # configure tracing
     if nipap_config.has_section("tracing"):
         try:
-            import tracing
+            import nipap.tracing
             from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
-            tracing.init_tracing("nipap-www", nipap_config.get("tracing", "otlp_grpc_endpoint"))
+            nipap.tracing.init_tracing("nipap-www", nipap_config.get("tracing", "otlp_grpc_endpoint"))
             app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
         except KeyError:
             pass


### PR DESCRIPTION
The init_tracing function referred to when initializing tracing in the web UI should be imported from the common NIPAP tracing module.