### PR TITLE
Fix handling of CA certificates in Dockerfile

### DIFF
--- a/Dockerfile.nipapd
+++ b/Dockerfile.nipapd
@@ -52,12 +52,14 @@ RUN apt-get update -qy && apt-get upgrade -qy \
  && apt-get clean
 
 # Install any additional CA certs from ca_certs folder required by corp proxies etc
-COPY ca_certs/ /
+RUN mkdir /ca_certs
+COPY ca_certs/ /ca_certs/
 RUN mkdir -p /usr/local/share/ca-certificates \
  && cp /ca_certs/*.crt /usr/local/share/ca-certificates/ || true \
  && rm -rf /ca_certs \
  && update-ca-certificates
 RUN pip3 config set global.cert /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 
 COPY nipap /nipap

--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -48,6 +48,16 @@ RUN apt-get update -qy && apt-get upgrade -qy \
  && pip3 --no-input install --no-cache-dir envtpl==0.7.2 \
  && apt-get clean
 
+# Install any additional CA certs from ca_certs folder required by corp proxies etc
+RUN mkdir /ca_certs
+COPY ca_certs/ /ca_certs/
+RUN mkdir -p /usr/local/share/ca-certificates \
+ && cp /ca_certs/*.crt /usr/local/share/ca-certificates/ || true \
+ && rm -rf /ca_certs \
+ && update-ca-certificates
+RUN pip3 config set global.cert /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 # Install pynipap, nipap and nipap-www
 COPY pynipap /pynipap
 COPY nipap /nipap


### PR DESCRIPTION
Fix the handling of CA certificates in Dockerfile.nipapd - the previous implementation simply didn't work as the Dockerfile COPY command only copies directory content and not the directory itself.
Also added the same handling to Dockerfile.www.