### PR TITLE
Fix trace proxy, improve logs

### DIFF
--- a/nipap/nipap/tracing.py
+++ b/nipap/nipap/tracing.py
@@ -2,7 +2,7 @@ try:
     import inspect
     from functools import wraps
 
-    from flask import request
+    from flask import request, abort
 
     from opentelemetry import trace, context
     from opentelemetry.trace import SpanKind, StatusCode
@@ -34,9 +34,23 @@ try:
 
 
     def setup(app, endpoint):
+        """ Set up an endpoint which proxies traces to the OpenTelemetry receiver.
+
+            This can be used by for example the NIPAP CLI.
+        """
         @app.route('/v1/traces/', defaults={'path': ''}, methods=["POST"])
         def proxy(path):
-            return post(f'{endpoint}{path}', data=request.data, headers=request.headers).content
+
+            # Remove Host-header as it's set to the host running nipapd.
+            headers = {k: v for k, v in request.headers}
+            headers.pop("Host", None)
+            res = post(f'{endpoint}{path}', data=request.data, headers=headers)
+
+            # Check result and abort with error if not successful
+            if res.status_code >= 400:
+                abort(res.status_code, description=res.text)
+
+            return res.content
 
 
     def create_span(f):

--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -257,13 +257,14 @@ if __name__ == '__main__':
             try:
                 setup(app, cfg.get("tracing", "otlp_http_endpoint"))
             except configparser.NoOptionError:
+                logger.info('Found no OTLP HTTP endpoint, OTLP proxy disabled')
                 pass
-            logger.debug('Tracing is enabled')
+            logger.debug('Tracing is enabled and successfully set up')
         except KeyError:
-            logger.error('Error in tracing configuration. No tracing enabled')
+            logger.error('Error in tracing configuration, tracing not enabled')
             pass
-        except ImportError:
-            logger.error('Failed to import tracing libraries. Check dependencies. No tracing enabled')
+        except ImportError as err:
+            logger.error('Failed to import tracing library %s, tracing not enabled', err.name)
             pass
     else:
         logger.debug('Tracing is disabled')


### PR DESCRIPTION
Fix the tracing proxy function by removing the Host header from the headers received from tracing client before POST:ing it to the tracing receiver.

Improve logging of how the setup of tracing is progressing.