### PR TITLE
Read global configuration in CLI

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     }
     # read configuration
     cfg = configparser.ConfigParser(cfg_defaults, allow_no_value=True)
-    cfg.read(userrcfile)
+    cfg.read(['/etc/nipaprc', userrcfile])
     nipap_cli.nipap_cli.cfg = cfg
 
     if cfg.has_section("tracing"):


### PR DESCRIPTION
Added the possibility to add global run-time configuration to the NIPAP CLI in /etc/nipaprc. The global file, if exists, will be read first and any option set in the local ~/.nipaprc file will override what's set in the global file.