### PR TITLE
Fixed default config for port in CLI

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     # config defaults
     cfg_defaults = {
         'hostname': 'localhost',
-        'post': 1337,
+        'port': 1337,
         'password': None,
         'prefix_list_columns': None,
         'use_ssl': 'false'


### PR DESCRIPTION
There was a typo causing the default config for port being missing.