### PR TITLE
Fork also when running in foreground

### DIFF
--- a/nipap/nipapd
+++ b/nipap/nipapd
@@ -329,8 +329,8 @@ if __name__ == '__main__':
     except:
         pass
 
-    # pre-fork if we are not running in foreground
-    if not cfg.getboolean('nipapd', 'foreground') and num_forks is not False:
+    # pre-fork unless explicitly disabled
+    if num_forks is not False:
         # default is to fork as many processes as there are cores
         tornado.process.fork_processes(num_forks)
 


### PR DESCRIPTION
Since forever nipapd have avoided to fork multiple processes when running in forground. I think the idea was to simplify debugging etc, never to be used in production. However, when deploying nipapd as a Docker container the process is running is foreground by default also in production and thus the behaviour is now changed to fork also for that case.