### PR TITLE
Fix to LDAP RO group validation and CLI credentials quoting

### DIFF
--- a/nipap-cli/nipap_cli/nipap_cli.py
+++ b/nipap-cli/nipap_cli/nipap_cli.py
@@ -87,8 +87,8 @@ def setup_connection():
         con_params['password'] = getpass.getpass()
 
     # Quote username & password
-    con_params['username'] = quote(con_params['username'])
-    con_params['password'] = quote(con_params['password'])
+    con_params['username'] = quote(con_params['username'], safe="")
+    con_params['password'] = quote(con_params['password'], safe="")
 
     # build XML-RPC URI
     pynipap.xmlrpc_uri = "%(protocol)s://%(username)s:%(password)s@%(hostname)s:%(port)s" % con_params

--- a/nipap/nipap/authlib.py
+++ b/nipap/nipap/authlib.py
@@ -553,6 +553,8 @@ class LdapAuth(BaseAuth):
                 ['cn', 'memberOf'],
             )
 
+            self._logger.debug("User %s is member of groups: %s", self.username, res[0][1].get('memberOf', []))
+
             # Data received from LDAP is bytes, make sure to decode/encode
             # accordingly before using it
             if res[0][1]['cn'][0] is not None:
@@ -569,7 +571,7 @@ class LdapAuth(BaseAuth):
                     # if ro_group is configured, and the user is a member of
                     # neither the ro_group nor the rw_group, fail authentication.
                     if self._ldap_ro_group:
-                        if self._ldap_ro_group not in res[0][1].get('memberOf', []):
+                        if self._ldap_ro_group.encode('utf-8') not in res[0][1].get('memberOf', []):
                             self._authenticated = False
                             return self._authenticated
                     else:


### PR DESCRIPTION
The read-only group name validation was missing an UTF-8 encode.
Improved the quoting of the credentials made by the CLI.