### PR TITLE
authlib: Avoid following LDAP referrals

### DIFF
--- a/nipap/nipap.conf.dist
+++ b/nipap/nipap.conf.dist
@@ -113,7 +113,7 @@ db_path = /etc/nipap/local_auth.db     ; path to SQLite database used
 #
 #basedn = ou=Users,dc=example,dc=com       ; base DN
 #uri = ldaps://ldap.example.com            ; LDAP server URI
-#tls = False                            ; initiate TLS, use ldap://
+#tls = false                               ; initiate TLS, use ldap://
 #
 # LDAP style
 #binddn_fmt = uid={},ou=Users,dc=example,dc=com


### PR DESCRIPTION
LDAP referrals seems to be a somewhat broken concept. By default the LDAP module uses a default anonymous bind to follow referrals which I would expect rarely (never) works. As NIPAP does not support setting up a separate connection for the referrals today, we just skip following them for now.

Also avoided sending full LDAP error messages to clients and instead make sure the error is logged.