### PR TITLE
pynipap as a package

### DIFF
--- a/nipap-cli/nipap
+++ b/nipap-cli/nipap
@@ -13,8 +13,7 @@ import socket
 import nipap_cli
 import nipap_cli.nipap_cli
 from nipap_cli.command import Command, CommandError
-from pynipap import NipapError
-import tracing
+from pynipap import NipapError, tracing
 
 # early close of stdout to avoid broken pipe, see #464
 # If our output is being piped and the receiver of the pipe is killed off before

--- a/pynipap/Makefile
+++ b/pynipap/Makefile
@@ -49,6 +49,6 @@ clean:
 VER := $(shell head -n1 ../NEWS | awk '{print $$2}')
 bumpversion:
 	# replace version number in pynipap.py
-	sed -i 's/\(__version__\s*= \)"[^"]\+"/\1"$(VER)"/' pynipap.py
+	sed -i 's/\(__version__\s*= \)"[^"]\+"/\1"$(VER)"/' pynipap/__init__.py
 	#         # update debian/changelog
 	../utilities/news2dch.py ../NEWS debian/changelog

--- a/pynipap/pynipap/__init__.py
+++ b/pynipap/pynipap/__init__.py
@@ -1,0 +1,23 @@
+from .pynipap import *
+
+__version__     = "0.32.5"
+__author__      = "Kristian Larsson, Lukas Garberg"
+__author_email__= "kll@tele2.net, lukas@spritelink.net"
+__copyright__   = "Copyright 2011, Kristian Larsson, Lukas Garberg"
+__license__     = "MIT"
+__status__      = "Development"
+__url__         = "http://SpriteLink.github.io/NIPAP"
+
+
+# This variable holds the URI to the nipap XML-RPC service which will be used.
+# It must be set before the Pynipap can be used!
+xmlrpc_uri = None
+
+# If set, the value assigned to the variable below will be used as a bearer
+# token.
+bearer_token = None
+
+# Caching of objects is enabled per default but can be disabled for certain
+# scenarios. Since we don't have any cache expiration time it can be useful to
+# disable for long running applications.
+CACHE = True

--- a/pynipap/pynipap/pynipap.py
+++ b/pynipap/pynipap/pynipap.py
@@ -209,27 +209,7 @@ import logging
 import xmlrpc.client as xmlrpclib
 import urllib.parse
 
-from tracing import create_span
-
-__version__		= "0.32.5"
-__author__		= "Kristian Larsson, Lukas Garberg"
-__author_email__= "kll@tele2.net, lukas@spritelink.net"
-__copyright__	= "Copyright 2011, Kristian Larsson, Lukas Garberg"
-__license__		= "MIT"
-__status__		= "Development"
-__url__			= "http://SpriteLink.github.io/NIPAP"
-
-
-# This variable holds the URI to the nipap XML-RPC service which will be used.
-# It must be set before the Pynipap can be used!
-xmlrpc_uri = None
-bearer_token = None
-
-# Caching of objects is enabled per default but can be disabled for certain
-# scenarios. Since we don't have any cache expiration time it can be useful to
-# disable for long running applications.
-CACHE = True
-
+from .tracing import create_span
 class AuthOptions:
     """ A global-ish authentication option container.
 
@@ -261,8 +241,6 @@ class XMLRPCConnection:
     """ Handles a shared XML-RPC connection.
     """
 
-    __shared_state = {}
-
     connection = None
     _logger = None
 
@@ -275,13 +253,19 @@ class XMLRPCConnection:
             variable is set.
         """
 
+        # This is not a pretty solution, but needed to maintain backwards
+        # compatibility and avoiding circular imports.
+        from . import xmlrpc_uri, bearer_token, CACHE as cache_enabled
+        global CACHE
+        CACHE = cache_enabled
+
         if xmlrpc_uri is None:
             raise NipapError('XML-RPC URI not specified')
 
         p = urllib.parse.urlsplit(xmlrpc_uri)
 
         try:
-            from tracing import TracingXMLTransport, TracingXMLSafeTransport
+            from .tracing import TracingXMLTransport, TracingXMLSafeTransport
             if p.scheme == "http":
                 xml_transport = TracingXMLTransport
             elif p.scheme == "https":
@@ -1520,6 +1504,10 @@ _cache = {
     'Prefix': {},
     'VRF': {}
 }
+
+# Will be overwritten by import from . when setting up XML-RPC-connection, but
+# needs to be defined here if it's read before the connections is set up.
+CACHE = False
 
 # Map from XML-RPC Fault codes to Exception classes
 _fault_to_exception_map = {

--- a/pynipap/pynipap/tracing.py
+++ b/pynipap/pynipap/tracing.py
@@ -49,7 +49,7 @@ try:
             """
             """
 
-            from pynipap import AuthOptions
+            from . import AuthOptions
             signature = inspect.signature(f)
 
             if args[0].__class__ == type:

--- a/pynipap/setup.py
+++ b/pynipap/setup.py
@@ -17,7 +17,7 @@ setup(
         author_email = pynipap.__author_email__,
         license = pynipap.__license__,
         url = pynipap.__url__,
-        py_modules = ['pynipap','tracing'],
+        packages = ['pynipap'],
         keywords = ['nipap'],
         classifiers = [
             'Development Status :: 4 - Beta',
@@ -26,7 +26,6 @@ setup(
             'License :: OSI Approved :: MIT License',
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3',
-            'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware'
+            'Programming Language :: Python :: 3'
             ]
 )


### PR DESCRIPTION
Mainly to avoid cluttering the global namespace with the name "tracing", moved the pynipap module to its own package.

The intention is that the package should be fully compatible with the stand-alone module and require no changes to the applications using it.