### PR TITLE
Docker fixes to WWW for new nipap packaging

### DIFF
--- a/nipap-www/entrypoint.sh
+++ b/nipap-www/entrypoint.sh
@@ -7,15 +7,15 @@ fi
 
 # Create NIPAP configuration file
 if [ ! -e /etc/nipap/nipap.conf ]; then
-    envtpl --keep-template --allow-missing -o /etc/nipap/nipap.conf /nipap/nipap.conf.dist
+    envtpl --keep-template --allow-missing -o /etc/nipap/nipap.conf /usr/local/share/nipap/nipap.conf.dist
 fi
 
 # Set up local auth database
 if [ ! -e /etc/nipap/local_auth.db ]; then
-    /usr/sbin/nipap-passwd create-database
+    /usr/local/bin/nipap-passwd create-database
 fi
 if [ `nipap-passwd list | egrep -c ^$WWW_USERNAME\\\s` -eq 0 ]; then
-    /usr/sbin/nipap-passwd add -u $WWW_USERNAME -p $WWW_PASSWORD -n "NIPAP WWW user" -t
+    /usr/local/bin/nipap-passwd add -u $WWW_USERNAME -p $WWW_PASSWORD -n "NIPAP WWW user" -t
 fi
 
 # Configure apache


### PR DESCRIPTION
Changes to the nipap-www Docker setup to handle changes introduced by new packaging of nipap.

* Correct path to nipap-passwd
* Correct path to sample config file