### PR TITLE
Build images with optional dependencies

### DIFF
--- a/Dockerfile.nipapd
+++ b/Dockerfile.nipapd
@@ -67,7 +67,7 @@ ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 COPY nipap /nipap
 WORKDIR /nipap
 RUN pip3 --no-input install --break-system-packages --no-cache-dir envtpl==0.7.2 \
- && pip3 --no-input install -I --break-system-packages --no-cache-dir .
+ && pip3 --no-input install -I --break-system-packages --no-cache-dir '.[instrumentation,ldap_auth]'
 
 EXPOSE 1337
 ENV LISTEN_ADDRESS=0.0.0.0 LISTEN_PORT=1337 SYSLOG=false DB_PORT=5432 DB_SSLMODE=disable DB_NAME=nipap

--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -64,8 +64,8 @@ COPY pynipap /pynipap
 COPY nipap /nipap
 COPY nipap-www /nipap-www
 RUN pip3 --no-input install --break-system-packages --no-cache-dir ./pynipap/ && \
-    pip3 --no-input install --break-system-packages --no-cache-dir ./nipap/ && \
-    pip3 --no-input install --break-system-packages --no-cache-dir ./nipap-www/ && \
+    pip3 --no-input install --break-system-packages --no-cache-dir './nipap/[instrumentation,ldap_auth]' && \
+    pip3 --no-input install --break-system-packages --no-cache-dir './nipap-www/[instrumentation,ldap_auth]' && \
     mkdir -p /etc/nipap/www/ && cp ./nipap-www/nipap-www.wsgi /etc/nipap/www/
 
 EXPOSE 80

--- a/nipap-www/pyproject.toml
+++ b/nipap-www/pyproject.toml
@@ -36,6 +36,10 @@ instrumentation = [
   "opentelemetry-util-http==0.50b0"
 ]
 
+ldap_auth = [
+  "python-ldap==3.4.4"
+]
+
 [project.urls]
 Homepage = "http://SpriteLink.github.io/NIPAP"
 


### PR DESCRIPTION
When moving dependencies to the pyproject.toml-files some dependencies were marked as extras, namely the LDAP module and OpenTelemetry-libraries. This change updates the Dockerfiles to build the images with these dependencies.