### PR TITLE
Fix debconf questions in Debian package installation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,13 @@ jobs:
       run: |
         # build new NIPAP packages
         make builddeb
+        # Pre-seed debconf answers before installing packages
+        echo "nipapd nipapd/database_host string localhost" | sudo debconf-set-selections
+        echo "nipapd nipapd/local_db_autoconf boolean true" | sudo debconf-set-selections
+        echo "nipapd nipapd/startup boolean true" | sudo debconf-set-selections
+        echo "nipapd nipapd/local_db_upgrade boolean true" | sudo debconf-set-selections
         # install the newly built nipap packages
         sudo apt install -o Dpkg::Options::="--force-confnew" ./nipap*.deb ./python*-pynipap*.deb
-        # populate answers to nipapd package install questions and reconfigure
-        echo 'set nipapd/database_host localhost' | sudo debconf-communicate
-        echo 'set nipapd/local_db_autoconf true' | sudo debconf-communicate
-        echo 'set nipapd/startup true' | sudo debconf-communicate
-        echo 'set nipapd/local_db_upgrade true' | sudo debconf-communicate
-        sudo dpkg-reconfigure nipapd
         # Enable SSL
         if [ `grep -c ssl_port /etc/nipap/nipap.conf` -eq 0 ]; then \
           # No SSL config in file - add from scratch

--- a/nipap/MANIFEST.in
+++ b/nipap/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst MANIFEST.in
 include *.man.rst
 include requirements.txt
+include nipap.conf.dist

--- a/nipap/MANIFEST.in
+++ b/nipap/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst MANIFEST.in
 include *.man.rst
 include requirements.txt
 include nipap.conf.dist
+recursive-include sql *.plsql

--- a/nipap/pyproject.toml
+++ b/nipap/pyproject.toml
@@ -71,6 +71,23 @@ nipap-passwd = "nipap.nipap_passwd:run"
 [tool.setuptools.dynamic]
 version = {attr = "nipap.__version__"}
 
+[tool.setuptools.data-files]
+"share/nipap" = ["nipap.conf.dist"]
+"share/nipap/sql" = [
+    "sql/upgrade-1-2.plsql",
+    "sql/upgrade-2-3.plsql",
+    "sql/upgrade-3-4.plsql",
+    "sql/upgrade-4-5.plsql",
+    "sql/upgrade-5-6.plsql",
+    "sql/upgrade-6-7.plsql",
+    "sql/upgrade-7-8.plsql",
+    "sql/functions.plsql",
+    "sql/triggers.plsql",
+    "sql/ip_net.plsql",
+]
+"share/man/man8" = ["nipapd.8"]
+"share/man/man1" = ["nipap-passwd.1"]
+
 [build-system]
 requires = [
   "setuptools",

--- a/nipap/setup.py
+++ b/nipap/setup.py
@@ -4,12 +4,10 @@ from setuptools import setup
 from docutils.core import publish_cmdline
 from docutils.writers import manpage
 import sys
-import re
 
 
-# return all the extra data files
-def get_data_files():
-    # generate man pages using rst2man
+def generate_manpages():
+    """Generate man pages from RST sources."""
     try:
         publish_cmdline(writer=manpage.Writer(), argv=["nipapd.man.rst", "nipapd.8"])
         publish_cmdline(writer=manpage.Writer(), argv=["nipap-passwd.man.rst", "nipap-passwd.1"])
@@ -17,26 +15,9 @@ def get_data_files():
         print("rst2man failed to run: %s" % str(exc), file=sys.stderr)
         sys.exit(1)
 
-    files = [
-        ('share/nipap/', ['nipap.conf.dist']),
-        ('share/nipap/sql/', [
-            'sql/upgrade-1-2.plsql',
-            'sql/upgrade-2-3.plsql',
-            'sql/upgrade-3-4.plsql',
-            'sql/upgrade-4-5.plsql',
-            'sql/upgrade-5-6.plsql',
-            'sql/upgrade-6-7.plsql',
-            'sql/functions.plsql',
-            'sql/triggers.plsql',
-            'sql/ip_net.plsql',
-        ],
-        ),
-        ('share/man/man8/', ['nipapd.8']),
-        ('share/man/man1/', ['nipap-passwd.1']),
-    ]
 
-    return files
-
+# Generate man pages before packaging
+generate_manpages()
 
 long_desc = open('README.rst').read()
 short_desc = long_desc.split('\n')[0].split(' - ')[1].strip()
@@ -46,5 +27,4 @@ setup(
     long_description=long_desc,
     packages=['nipap'],
     keywords=['nipap'],
-    data_files=get_data_files(),
 )


### PR DESCRIPTION
Use debconf-set-selections to pre-seed debconf answers before package installation instead of using debconf-communicate after installation.